### PR TITLE
Added jib configuration to generate docker images from maven

### DIFF
--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/pom.xml
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/pom.xml
@@ -77,6 +77,36 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>com.google.cloud.tools</groupId>
+				<artifactId>jib-maven-plugin</artifactId>
+				<configuration>
+					<skip>false</skip>
+					<container>
+						<!-- enable this if you do not care about reproducable builds, but
+							 prefer container creation times to be related to commit/build time
+							 <creationTime>USE_CURRENT_TIMESTAMP</creationTime>
+							 -->
+						<ports>
+							<port>8080</port>
+						</ports>
+					</container>
+					<from>
+						<!-- remove -debug on release versions, the debug version allow you to at least get a shell into the container -->
+						<image>gcr.io/distroless/java:8-debug</image>
+					</from>
+					<to>
+						<!-- read https://github.com/GoogleContainerTools/jib/blob/master/jib-maven-plugin/README.md#using-amazon-elastic-container-registry-ecr -->
+						<!-- can also be changed from command line: -Djib.to.image= -->
+						<image>979586646521.dkr.ecr.eu-west-1.amazonaws.com/ubiquevscovid19-ws:test</image>
+						<tags>
+							<!-- these are extra tags on top of the optional tag in the image name (else latest) -->
+							<!-- can also be further extended from command line with -Djib.to.tags= -->
+							<tag>${project.version}</tag>
+						</tags>
+					</to>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/dpppt-backend-sdk/pom.xml
+++ b/dpppt-backend-sdk/pom.xml
@@ -226,6 +226,15 @@
 					<artifactId>jacoco-maven-plugin</artifactId>
 					<version>0.8.5</version>
 				</plugin>
+				<plugin> <!-- automatically build docker containers from maven -->
+					<!-- docs: https://github.com/GoogleContainerTools/jib/blob/master/jib-maven-plugin/README.md -->
+					<groupId>com.google.cloud.tools</groupId>
+					<artifactId>jib-maven-plugin</artifactId>
+					<version>1.8.0</version>
+					<configuration>
+						<skip>true</skip>
+					</configuration>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 	</build>


### PR DESCRIPTION
As discussed in #6 I offered to help setup jib in maven so that you can avoid maintaining a custom dockerfile.

## Running it

Currently you can run this branch as follows:

```
 mvn package jib:buildTar
```

which wil create a tar in the target folder that you could either manually shared with someone else (or a registry), or load locally:

```
$ docker load -i dpppt-backend-sdk-ws/target/jib-image.tar
Loaded image: 979586646521.dkr.ecr.eu-west-1.amazonaws.com/ubiquevscovid19-ws:test
Loaded image: 979586646521.dkr.ecr.eu-west-1.amazonaws.com/ubiquevscovid19-ws:1.0.0-SNAPSHOT
```

if you run:

```
 mvn package jib:build
```

it will actually try to upload it to your configured aws registry, but it needs [amazon-ecr-credential-helper](https://github.com/awslabs/amazon-ecr-credential-helper) to work.

you can also run:

```
mvn package jib:dockerBuild
```

Which is the only command that actually requires an installation of docker on the machine that runs maven. It just builds the tar, and automatically loads it into your local docker instance.

Using these commands, and quite some available parameters, you can setup jib to nicely build docker containers during your CI.

## Still open

Currently there are some configuration paths that I do not know, as they are not committed, so maybe someone can continue with that. So if you run the container, it just starts and crashes due to not knowing where to find the postgres db.

## Reference points

Interesting documentation on jib:

- https://github.com/GoogleContainerTools/jib/blob/master/jib-maven-plugin/README.md
- https://github.com/GoogleContainerTools/jib/blob/master/docs/faq.md

