### PR TITLE
Added dependecy check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,18 @@ LATEX = xelatex
 BIBER = biber
 RUSTY_SWAGGER = rusty-swagger
 
+.PHONY: scan-dependencies show-vulnerabilities-report
+
+OPEN = open
+
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Linux)
+   OPEN = xdg-open
+endif
+
 all: clean all1
-all1: clean updateproject swagger la la2 la3 
-no: clean updateproject swagger la la2 
+all1: clean updateproject swagger la la2 la3
+no: clean updateproject swagger la la2
 docker-build: updateproject docker
 
 updateproject:
@@ -29,13 +38,17 @@ la2:
 la3:
 	cd documentation;$(LATEX) $(FILE_NAME)
 show:
-	cd documentation; open $(FILE_NAME).pdf &
+	cd documentation; $(OPEN) $(FILE_NAME).pdf &
 
 docker:
 	cp dpppt-backend-sdk/dpppt-backend-sdk-ws/target/dpppt-backend-sdk-ws-1.0.0-SNAPSHOT.jar ws-sdk/ws/bin/dpppt-backend-sdk-ws-1.0.0.jar
 	docker build -t 979586646521.dkr.ecr.eu-west-1.amazonaws.com/ubiquevscovid19-ws:test ws-sdk/
-	
-
 
 clean:
 	@rm -f documentation/*.log documentation/*.aux documentation/*.dvi documentation/*.ps documentation/*.blg documentation/*.bbl documentation/*.out documentation/*.bcf documentation/*.run.xml documentation/*.fdb_latexmk documentation/*.fls documentation/*.toc
+
+scan-dependencies:
+	cd dpppt-backend-sdk; mvn verify
+
+show-vulnerabilities-report:
+	cd dpppt-backend-sdk; $(OPEN) dpppt-backend-sdk-model/target/dependency-check-report.html

--- a/README.md
+++ b/README.md
@@ -97,6 +97,11 @@ To build the docker image run
 make docker-build
 ```
 
+### Scanning for vulnerabilities
+
+OWAS dependency check is included in the `mvn verify` command.
+
+`make scan-dependencies` and `make show-vulnerabilities-report` are the shortcuts to it.
 
 
 ## License

--- a/dpppt-backend-sdk/pom.xml
+++ b/dpppt-backend-sdk/pom.xml
@@ -208,6 +208,18 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.owasp</groupId>
+				<artifactId>dependency-check-maven</artifactId>
+				<version>5.3.2</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>check</goal>
+						</goals>
+					</execution>
+				</executions>
+            </plugin>
 		</plugins>
 		<pluginManagement>
 			<plugins>


### PR DESCRIPTION
Dear team, here I integrate a dependency check tool into your maven build.
I am sure you know, why it is important to keep java dependencies up to date.
The scanner can help you being informed once the patches are needed.

I have also modified the Makefile and the Readme.md to help run the scans.

The Makefile uses `open` command which does not quite work on Linux. I have
aliased it to be xdg-open on Linux and to stay the same on other OSes.