### PR TITLE
create and read public and private key in pem format

### DIFF
--- a/GenerateKeyPairEC.java
+++ b/GenerateKeyPairEC.java
@@ -14,26 +14,46 @@ import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.util.Base64;
 import java.security.spec.ECGenParameterSpec;
+import java.io.StringWriter;
 
 import java.security.Security;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.util.io.pem.PemWriter;
+import org.bouncycastle.util.io.pem.PemObject;
 
 public class GenerateKeyPairEC{
     public static void main(String[] args) throws Exception {
-		Security.addProvider(new BouncyCastleProvider());
-		Security.setProperty("crypto.policy", "unlimited");
-		KeyPairGenerator generator =  KeyPairGenerator.getInstance("ECDSA", "BC");
-		ECGenParameterSpec spec = new ECGenParameterSpec("secp256r1");
-		generator.initialize(spec);
-		KeyPair pair = generator.genKeyPair();
-		PrivateKey privateKey = pair.getPrivate();
-		PublicKey publicKey = pair.getPublic();
-		FileOutputStream outputStream = new FileOutputStream("generated_pub.pem");
-		outputStream.write(Base64.getEncoder().encode(publicKey.getEncoded()));
+        Security.addProvider(new BouncyCastleProvider());
+        Security.setProperty("crypto.policy", "unlimited");
+        KeyPairGenerator generator =  KeyPairGenerator.getInstance("ECDSA", "BC");
+        ECGenParameterSpec spec = new ECGenParameterSpec("secp256r1");
+        generator.initialize(spec);
+        KeyPair pair = generator.genKeyPair();
+        PrivateKey privateKey = pair.getPrivate();
+        PublicKey publicKey = pair.getPublic();
+
+        StringWriter privateKeyWriter = new StringWriter();
+        PemWriter privateKeyPemWriter = new PemWriter(privateKeyWriter);
+        privateKeyPemWriter.writeObject(new PemObject("PRIVATE KEY", privateKey.getEncoded()));
+        privateKeyPemWriter.flush();
+        privateKeyPemWriter.close();
+
+        StringWriter publicKeyWriter = new StringWriter();
+        PemWriter publicKeyPemWriter = new PemWriter(publicKeyWriter);
+        publicKeyPemWriter.writeObject(new PemObject("PUBLIC KEY", publicKey.getEncoded()));
+        publicKeyPemWriter.flush();
+        publicKeyPemWriter.close();
+
+        FileOutputStream outputStream = new FileOutputStream("generated_pub.pem");
+        outputStream.write(Base64.getEncoder().encode(
+            publicKeyWriter.toString().getBytes()
+        ));
         outputStream.close();
         
         outputStream = new FileOutputStream("generated_private.pem");
-		outputStream.write(Base64.getEncoder().encode(privateKey.getEncoded()));
-		outputStream.close();
+        outputStream.write(Base64.getEncoder().encode(
+            privateKeyWriter.toString().getBytes()
+        ));
+        outputStream.close();
     }
 }


### PR DESCRIPTION
currently the GenerateKeyPairEC generates a public key in base64 encoded DER format, but they are not read correctly by the WSCloudBaseConfig. 
I propose to write them directly in PEM format, encode in Base64 everything and read them this way from the property. Also, to read the public key directly instead of reading it from a certificate. I don't know if the idea is to make a CA sign the public key doing a CSR, but if it's not the case this way is more straighforward. 
I've tested it for the Spanish app proposal and it works correctly with values generated this way, also client side the app verifies the JWS correctly.