### PR TITLE
Reject JWT that expire too far in the future, or never expire at all

### DIFF
--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/config/WSJWTConfig.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/config/WSJWTConfig.java
@@ -18,6 +18,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.interfaces.RSAPublicKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.X509EncodedKeySpec;
+import java.time.Duration;
 import java.util.Base64;
 
 import org.apache.commons.io.IOUtils;
@@ -52,6 +53,9 @@ public class WSJWTConfig extends WebSecurityConfigurerAdapter {
 
 	@Value("${ws.app.jwt.publickey}")
 	String publicKey;
+
+	@Value("${ws.app.jwt.maxValidityMinutes: 60}")
+	int maxValidityMinutes;
 
 	@Autowired
 	@Lazy
@@ -88,7 +92,7 @@ public class WSJWTConfig extends WebSecurityConfigurerAdapter {
 
 	@Bean
 	public JWTValidator jwtValidator() {
-		return new JWTValidator(dataService);
+		return new JWTValidator(dataService, Duration.ofMinutes(maxValidityMinutes));
 	}
 
 	@Bean

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/controller/DPPPTControllerTest.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/controller/DPPPTControllerTest.java
@@ -256,4 +256,22 @@ public class DPPPTControllerTest extends BaseControllerTest {
         .andReturn().getResponse();
     }
 
+    @Test
+    public void cannotUsedLongLivedToken() throws Exception {
+        ExposeeRequest exposeeRequest = new ExposeeRequest();
+        exposeeRequest.setAuthData(new ExposeeAuthData());
+        exposeeRequest.setKeyDate(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).toInstant().toEpochMilli());
+        exposeeRequest.setKey(Base64.getEncoder().encodeToString("test".getBytes("UTF-8")));
+        exposeeRequest.setIsFake(0);
+        String token = createToken(OffsetDateTime.now(ZoneOffset.UTC).plusDays(90)); // very late expiration date
+        MockHttpServletResponse response = mockMvc.perform(post("/v1/exposed")
+                                                            .contentType(MediaType.APPLICATION_JSON)
+                                                            .header("Authorization", "Bearer " + token)
+                                                            .header("User-Agent", "MockMVC")
+                                                            .content(json(exposeeRequest)))
+                .andExpect(status().is(401))
+                .andExpect(content().string(""))
+                .andReturn().getResponse();
+    }
+
 }


### PR DESCRIPTION
Proposed fix for #77.

This fix adds a new config value "${ws.app.jwt.maxValidityMinutes: 60}".
I'm not entirely sure about its default value - it must be equal or greater to the validity that keycloak assigns to the generated JWTs, but I don't know the keycloak configuration.

And it's important that "${ws.app.jwt.maxValidityMinutes: 60}" is configured to be smaller than "${ws.retentiondays: 21}" to guarantee that tokens are not deleted before they expire.
I wanted to check this rule when the application starts, but as these two config values are in different config classes I'm not sure how to do that best.