### PR TITLE
Add configuration parameter to toggle signature debug headers

### DIFF
--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/config/WSBaseConfig.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/config/WSBaseConfig.java
@@ -10,13 +10,11 @@
 
 package org.dpppt.backend.sdk.ws.config;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.hubspot.jackson.datatype.protobuf.ProtobufModule;
-import io.jsonwebtoken.SignatureAlgorithm;
-import io.jsonwebtoken.security.Keys;
+import java.security.KeyPair;
+import java.util.List;
+
+import javax.sql.DataSource;
+
 import org.dpppt.backend.sdk.data.DPPPTDataService;
 import org.dpppt.backend.sdk.data.EtagGenerator;
 import org.dpppt.backend.sdk.data.EtagGeneratorInterface;
@@ -41,9 +39,14 @@ import org.springframework.scheduling.config.IntervalTask;
 import org.springframework.scheduling.config.ScheduledTaskRegistrar;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-import javax.sql.DataSource;
-import java.security.KeyPair;
-import java.util.List;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.hubspot.jackson.datatype.protobuf.ProtobufModule;
+
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
 
 @Configuration
 @EnableScheduling
@@ -62,6 +65,9 @@ public abstract class WSBaseConfig implements SchedulingConfigurer, WebMvcConfig
 
 	@Value("${ws.headers.protected:}")
 	List<String> protectedHeaders;
+
+	@Value("${ws.headers.debug: false}")
+	boolean setDebugHeaders;
 
 	@Value("${ws.retentiondays: 21}")
 	int retentionDays;
@@ -116,7 +122,7 @@ public abstract class WSBaseConfig implements SchedulingConfigurer, WebMvcConfig
 
 	@Bean
 	public ResponseWrapperFilter hashFilter() {
-		return new ResponseWrapperFilter(getKeyPair(algorithm), retentionDays, protectedHeaders);
+		return new ResponseWrapperFilter(getKeyPair(algorithm), retentionDays, protectedHeaders, setDebugHeaders);
 	}
 
 	public KeyPair getKeyPair(SignatureAlgorithm algorithm) {

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/filter/ResponseWrapperFilter.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/filter/ResponseWrapperFilter.java
@@ -31,24 +31,28 @@ public class ResponseWrapperFilter implements Filter {
 	private final KeyPair pair;
 	private final int retentionDays;
 	private final List<String> protectedHeaders;
-	
+	private final boolean setDebugHeaders;
+
 	public PublicKey getPublicKey() {
 		return pair.getPublic();
 	}
 
-	public ResponseWrapperFilter(KeyPair pair, int retentionDays, List<String> protectedHeaders) {
+	public ResponseWrapperFilter(KeyPair pair, int retentionDays, List<String> protectedHeaders,
+			boolean setDebugHeaders) {
 		Security.addProvider(new BouncyCastleProvider());
 		Security.setProperty("crypto.policy", "unlimited");
 		this.pair = pair;
-        this.retentionDays = retentionDays;
-        this.protectedHeaders = protectedHeaders;
+		this.retentionDays = retentionDays;
+		this.protectedHeaders = protectedHeaders;
+		this.setDebugHeaders = setDebugHeaders;
 	}
 
 	@Override
 	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
 			throws IOException, ServletException {
 		HttpServletResponse httpResponse = (HttpServletResponse) response;
-		SignatureResponseWrapper wrapper = new SignatureResponseWrapper(httpResponse, pair, retentionDays, protectedHeaders);
+		SignatureResponseWrapper wrapper = new SignatureResponseWrapper(httpResponse, pair, retentionDays,
+				protectedHeaders, setDebugHeaders);
 		chain.doFilter(request, wrapper);
 		wrapper.outputData(httpResponse.getOutputStream());
 	}

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/resources/application.properties
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/resources/application.properties
@@ -27,5 +27,6 @@ datasource.connectionTimeout=30000
 ws.exposedlist.cachecontrol=5
 ws.app.source=org.dpppt.demo
 ws.headers.protected=X-HELLO,X-BATCH-RELEASE-TIME
+#ws.headers.debug=true
 
 ws.app.jwt.publickey=

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/security/signature/SignatureResponseWrapperTest.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/security/signature/SignatureResponseWrapperTest.java
@@ -10,15 +10,10 @@
 
 package org.dpppt.backend.sdk.ws.security.signature;
 
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jwt;
-import io.jsonwebtoken.JwtParser;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
-import io.jsonwebtoken.security.Keys;
-import org.apache.commons.codec.binary.Hex;
-import org.junit.Test;
-import org.springframework.mock.web.MockHttpServletResponse;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -30,98 +25,145 @@ import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import org.apache.commons.codec.binary.Hex;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletResponse;
 
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwt;
+import io.jsonwebtoken.JwtParser;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
 
 /**
- * @author bachmann
- * created on 24.04.20
+ * @author bachmann created on 24.04.20
  **/
 public class SignatureResponseWrapperTest {
 
+	private MockHttpServletResponse response;
 
-    private MockHttpServletResponse response;
+	@Test
+	public void testSignaturResponseWrapper() throws IOException, NoSuchAlgorithmException {
 
-    @Test
-    public void testSignaturResponseWrapper() throws IOException, NoSuchAlgorithmException {
+		response = new MockHttpServletResponse();
+		KeyPair keyPair = Keys.keyPairFor(SignatureAlgorithm.ES256);
+		KeyPair wrongKey = Keys.keyPairFor(SignatureAlgorithm.ES256);
+		List<String> protectedHeaders = new ArrayList<String>();
+		protectedHeaders.add("X-BATCH-RELEASE-TIME");
+		SignatureResponseWrapper signatureResponseWrapper = new SignatureResponseWrapper(response, keyPair, 21,
+				protectedHeaders, true);
+		signatureResponseWrapper.getOutputStream().print("TEST");
+		signatureResponseWrapper.flushBuffer();
+		String digest = response.getHeader("Digest");
+		String rawJWT = response.getHeader("Signature");
+		assertNotNull(digest);
+		String expected = "sha-256="
+				+ Hex.encodeHexString(MessageDigest.getInstance("SHA-256").digest("TEST".getBytes()));
+		assertEquals(expected, digest);
 
-        response = new MockHttpServletResponse();
-        KeyPair keyPair = Keys.keyPairFor(SignatureAlgorithm.ES256);
-        KeyPair wrongKey = Keys.keyPairFor(SignatureAlgorithm.ES256);
-        List<String> protectedHeaders = new ArrayList<String>();
-        protectedHeaders.add("X-BATCH-RELEASE-TIME");
-        SignatureResponseWrapper signatureResponseWrapper = new SignatureResponseWrapper(response, keyPair, 21, protectedHeaders);
-        signatureResponseWrapper.getOutputStream().print("TEST");
-        signatureResponseWrapper.flushBuffer();
-        String digest = response.getHeader("Digest");
-        String rawJWT = response.getHeader("Signature");
-        assertNotNull(digest);
-        String expected = "sha-256=" + Hex.encodeHexString(MessageDigest.getInstance("SHA-256").digest("TEST".getBytes()));
-        assertEquals(expected, digest);
-        
-    }
+	}
 
-    @Test
-    public void testSignatureViaOutput() throws IOException, NoSuchAlgorithmException {
-        response = new MockHttpServletResponse();
-        KeyPair keyPair = Keys.keyPairFor(SignatureAlgorithm.ES256);
-        KeyPair wrongKey = Keys.keyPairFor(SignatureAlgorithm.ES256);
-        List<String> protectedHeaders = new ArrayList<String>();
-        protectedHeaders.add("X-BATCH-RELEASE-TIME");
-        SignatureResponseWrapper signatureResponseWrapper = new SignatureResponseWrapper(response, keyPair, 21, protectedHeaders);
-        signatureResponseWrapper.getOutputStream().print("TEST");
-        OutputStream stream = OutputStream.nullOutputStream();
-        signatureResponseWrapper.outputData(stream);
-        String digest = response.getHeader("Digest");
-        String rawJWT = response.getHeader("Signature");
-        assertNotNull(digest);
-        String expected = "sha-256=" + Hex.encodeHexString(MessageDigest.getInstance("SHA-256").digest("TEST".getBytes()));
-        assertEquals(expected, digest);
-    }
+	@Test
+	public void testSignatureViaOutput() throws IOException, NoSuchAlgorithmException {
+		response = new MockHttpServletResponse();
+		KeyPair keyPair = Keys.keyPairFor(SignatureAlgorithm.ES256);
+		KeyPair wrongKey = Keys.keyPairFor(SignatureAlgorithm.ES256);
+		List<String> protectedHeaders = new ArrayList<String>();
+		protectedHeaders.add("X-BATCH-RELEASE-TIME");
+		SignatureResponseWrapper signatureResponseWrapper = new SignatureResponseWrapper(response, keyPair, 21,
+				protectedHeaders, true);
+		signatureResponseWrapper.getOutputStream().print("TEST");
+		OutputStream stream = OutputStream.nullOutputStream();
+		signatureResponseWrapper.outputData(stream);
+		String digest = response.getHeader("Digest");
+		String rawJWT = response.getHeader("Signature");
+		assertNotNull(digest);
+		String expected = "sha-256="
+				+ Hex.encodeHexString(MessageDigest.getInstance("SHA-256").digest("TEST".getBytes()));
+		assertEquals(expected, digest);
+	}
 
-    @Test
-    public void testBatchReleaseTime() throws IOException, NoSuchAlgorithmException{
-        response = new MockHttpServletResponse();
-        response.setHeader("X-BATCH-RELEASE-TIME", Long.toString(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).toInstant().toEpochMilli()));
-        KeyPair keyPair = Keys.keyPairFor(SignatureAlgorithm.ES256);
-        KeyPair wrongKey = Keys.keyPairFor(SignatureAlgorithm.ES256);
-        List<String> protectedHeaders = new ArrayList<String>();
-        protectedHeaders.add("X-BATCH-RELEASE-TIME");
-        SignatureResponseWrapper signatureResponseWrapper = new SignatureResponseWrapper(response, keyPair, 21, protectedHeaders);
-        signatureResponseWrapper.getOutputStream().print("TEST");
-        signatureResponseWrapper.flushBuffer();
-        String digest = response.getHeader("Digest");
-        String rawJWT = response.getHeader("Signature");
-        JwtParser jwtParser = Jwts.parserBuilder().setSigningKey(keyPair.getPublic()).build();
-        Jwt jwt = jwtParser.parse(rawJWT);
-    
-        assertTrue(response.containsHeader("X-BATCH-RELEASE-TIME"));
-        Claims claims = (Claims)jwt.getBody();
-        assertTrue(claims.containsKey("batch-release-time"));
-    }
+	@Test
+	public void testBatchReleaseTime() throws IOException, NoSuchAlgorithmException {
+		response = new MockHttpServletResponse();
+		response.setHeader("X-BATCH-RELEASE-TIME",
+				Long.toString(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).toInstant().toEpochMilli()));
+		KeyPair keyPair = Keys.keyPairFor(SignatureAlgorithm.ES256);
+		KeyPair wrongKey = Keys.keyPairFor(SignatureAlgorithm.ES256);
+		List<String> protectedHeaders = new ArrayList<String>();
+		protectedHeaders.add("X-BATCH-RELEASE-TIME");
+		SignatureResponseWrapper signatureResponseWrapper = new SignatureResponseWrapper(response, keyPair, 21,
+				protectedHeaders, true);
+		signatureResponseWrapper.getOutputStream().print("TEST");
+		signatureResponseWrapper.flushBuffer();
+		String digest = response.getHeader("Digest");
+		String rawJWT = response.getHeader("Signature");
+		JwtParser jwtParser = Jwts.parserBuilder().setSigningKey(keyPair.getPublic()).build();
+		Jwt jwt = jwtParser.parse(rawJWT);
 
-    @Test
-    public void testBatchReleaseTimeWithOutputStream() throws IOException, NoSuchAlgorithmException{
-        response = new MockHttpServletResponse();
-        response.setHeader("X-BATCH-RELEASE-TIME", Long.toString(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).toInstant().toEpochMilli()));
-        KeyPair keyPair = Keys.keyPairFor(SignatureAlgorithm.ES256);
-        KeyPair wrongKey = Keys.keyPairFor(SignatureAlgorithm.ES256);
-        List<String> protectedHeaders = new ArrayList<String>();
-        protectedHeaders.add("X-BATCH-RELEASE-TIME");
-        SignatureResponseWrapper signatureResponseWrapper = new SignatureResponseWrapper(response, keyPair, 21, protectedHeaders);
-        signatureResponseWrapper.getOutputStream().print("TEST");
-        OutputStream stream = OutputStream.nullOutputStream();
-        signatureResponseWrapper.outputData(stream);
-        String digest = response.getHeader("Digest");
-        String rawJWT = response.getHeader("Signature");
-        JwtParser jwtParser = Jwts.parserBuilder().setSigningKey(keyPair.getPublic()).build();
-        Jwt jwt = jwtParser.parse(rawJWT);
-    
-        assertTrue(response.containsHeader("X-BATCH-RELEASE-TIME"));
-        Claims claims = (Claims)jwt.getBody();
-        assertTrue(claims.containsKey("batch-release-time"));
-    }
+		assertTrue(response.containsHeader("X-BATCH-RELEASE-TIME"));
+		Claims claims = (Claims) jwt.getBody();
+		assertTrue(claims.containsKey("batch-release-time"));
+	}
 
+	@Test
+	public void testBatchReleaseTimeWithOutputStream() throws IOException, NoSuchAlgorithmException {
+		response = new MockHttpServletResponse();
+		response.setHeader("X-BATCH-RELEASE-TIME",
+				Long.toString(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).toInstant().toEpochMilli()));
+		KeyPair keyPair = Keys.keyPairFor(SignatureAlgorithm.ES256);
+		KeyPair wrongKey = Keys.keyPairFor(SignatureAlgorithm.ES256);
+		List<String> protectedHeaders = new ArrayList<String>();
+		protectedHeaders.add("X-BATCH-RELEASE-TIME");
+		SignatureResponseWrapper signatureResponseWrapper = new SignatureResponseWrapper(response, keyPair, 21,
+				protectedHeaders, true);
+		signatureResponseWrapper.getOutputStream().print("TEST");
+		OutputStream stream = OutputStream.nullOutputStream();
+		signatureResponseWrapper.outputData(stream);
+		String digest = response.getHeader("Digest");
+		String rawJWT = response.getHeader("Signature");
+		JwtParser jwtParser = Jwts.parserBuilder().setSigningKey(keyPair.getPublic()).build();
+		Jwt jwt = jwtParser.parse(rawJWT);
+
+		assertTrue(response.containsHeader("X-BATCH-RELEASE-TIME"));
+		Claims claims = (Claims) jwt.getBody();
+		assertTrue(claims.containsKey("batch-release-time"));
+	}
+
+	@Test
+	public void testSignaturResponseWrapperWithDebugHeaders() throws IOException, NoSuchAlgorithmException {
+		response = new MockHttpServletResponse();
+		KeyPair keyPair = Keys.keyPairFor(SignatureAlgorithm.ES256);
+		List<String> protectedHeaders = new ArrayList<String>();
+		protectedHeaders.add("X-BATCH-RELEASE-TIME");
+		SignatureResponseWrapper signatureResponseWrapper = new SignatureResponseWrapper(response, keyPair, 21,
+				protectedHeaders, true);
+		signatureResponseWrapper.getOutputStream().print("TEST");
+		signatureResponseWrapper.flushBuffer();
+
+		String digest = response.getHeader("Digest");
+		assertNotNull(digest);
+
+		String publicKey = response.getHeader("X-Public-Key");
+		assertNotNull(publicKey);
+	}
+
+	@Test
+	public void testSignaturResponseWrapperWithoutDebugHeaders() throws IOException, NoSuchAlgorithmException {
+		response = new MockHttpServletResponse();
+		KeyPair keyPair = Keys.keyPairFor(SignatureAlgorithm.ES256);
+		List<String> protectedHeaders = new ArrayList<String>();
+		protectedHeaders.add("X-BATCH-RELEASE-TIME");
+		SignatureResponseWrapper signatureResponseWrapper = new SignatureResponseWrapper(response, keyPair, 21,
+				protectedHeaders, false);
+		signatureResponseWrapper.getOutputStream().print("TEST");
+		signatureResponseWrapper.flushBuffer();
+
+		String digest = response.getHeader("Digest");
+		assertNull(digest);
+
+		String publicKey = response.getHeader("X-Public-Key");
+		assertNull(publicKey);
+	}
 }


### PR DESCRIPTION
Debug headers (digest and public key) are not sent in HTTP responses by default.
They can be sent by adding the following parameter in configuration file:
ws.headers.debug=true