### PR TITLE
Bugfix/validate key size

### DIFF
--- a/dpppt-backend-sdk/dpppt-backend-sdk-model/src/main/java/org/dpppt/backend/sdk/model/ExposedKey.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-model/src/main/java/org/dpppt/backend/sdk/model/ExposedKey.java
@@ -1,23 +1,25 @@
 package org.dpppt.backend.sdk.model;
 
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 
 public class ExposedKey {
-    @NotNull
+	@NotNull
+	@Size(min = 24, max = 44)
 	private String key;
 
 	@NotNull
-    private long keyDate;
-    
-    public String getKey() {
+	private long keyDate;
+
+	public String getKey() {
 		return key;
 	}
 
 	public void setKey(String key) {
 		this.key = key;
-    }
-    
-    public long getKeyDate() {
+	}
+
+	public long getKeyDate() {
 		return keyDate;
 	}
 

--- a/dpppt-backend-sdk/dpppt-backend-sdk-model/src/main/java/org/dpppt/backend/sdk/model/ExposeeRequest.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-model/src/main/java/org/dpppt/backend/sdk/model/ExposeeRequest.java
@@ -11,12 +11,14 @@
 package org.dpppt.backend.sdk.model;
 
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 
 public class ExposeeRequest {
 
 	private Integer fake = 0;
 
 	@NotNull
+	@Size(min = 24, max = 44)
 	private String key;
 
 	@NotNull
@@ -47,7 +49,7 @@ public class ExposeeRequest {
 	public void setKeyDate(long keyDate) {
 		this.keyDate = keyDate;
 	}
-	
+
 	public Integer isFake() {
 		return fake;
 	}

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/DPPPTController.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/DPPPTController.java
@@ -54,7 +54,6 @@ import com.google.protobuf.ByteString;
 public class DPPPTController {
 	private static final int KEY_LENGTH_BYTES_GOOGLE_APPLE = 16;
 	private static final int KEY_LENGTH_BYTES_DP3T = 32;
-	private static final int MAX_KEY_LENGTH_BASE_64 = 44;
 
 	private final DPPPTDataService dataService;
 	private final EtagGeneratorInterface etagGenerator;
@@ -248,9 +247,6 @@ public class DPPPTController {
 
 	private boolean isValidBase64Key(String value) {
 		try {
-			if (value.length() > MAX_KEY_LENGTH_BASE_64) {
-				return false;
-			}
 			byte[] key = Base64.getDecoder().decode(value);
 			if (key.length != KEY_LENGTH_BYTES_DP3T && key.length != KEY_LENGTH_BYTES_GOOGLE_APPLE) {
 				return false;

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/controller/CloudControllerTestPEM.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/controller/CloudControllerTestPEM.java
@@ -10,16 +10,26 @@
 
 package org.dpppt.backend.sdk.ws.controller;
 
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import static org.junit.Assert.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.io.IOException;
+import java.security.PublicKey;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.Base64;
+
+import org.dpppt.backend.sdk.model.ExposeeAuthData;
 import org.dpppt.backend.sdk.model.ExposeeRequest;
 import org.dpppt.backend.sdk.ws.filter.ResponseWrapperFilter;
 import org.junit.Before;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
@@ -28,81 +38,62 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwt;
 import io.jsonwebtoken.Jwts;
 
-import java.io.IOException;
-import java.security.PublicKey;
-
-import java.time.LocalDate;
-import java.time.ZoneOffset;
-import java.util.Base64;
-
-
-import static org.junit.Assert.assertEquals;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import org.dpppt.backend.sdk.model.ExposeeAuthData;
-import org.junit.Test;
-
-import org.springframework.http.MediaType;
-
-
-
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles({ "test-cloud" })
-@TestPropertySource(properties = 
-{ 
-    "ws.app.source=org.dpppt.demo",
-    "vcap.services.ecdsa_dev.credentials.publicKey=LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNTRENDQWU2Z0F3SUJBZ0lVS3pEQlJIZlZVN2djRGZxUTBGUDFLTkJULzVJd0NnWUlLb1pJemowRUF3SXcKZXpFTE1Ba0dBMVVFQmhNQ1EwZ3hEVEFMQmdOVkJBZ01CRUpsY200eERUQUxCZ05WQkFjTUJFSmxjbTR4RERBSwpCZ05WQkFvTUEwSkpWREVNTUFvR0ExVUVDd3dEUlZkS01RMHdDd1lEVlFRRERBUlVaWE4wTVNNd0lRWUpLb1pJCmh2Y05BUWtCRmhSemRYQndiM0owUUdKcGRDNWhaRzFwYmk1amFEQWVGdzB5TURBME1qZ3hNakUwTlRGYUZ3MHkKTVRBME1qZ3hNakUwTlRGYU1Ic3hDekFKQmdOVkJBWVRBa05JTVEwd0N3WURWUVFJREFSQ1pYSnVNUTB3Q3dZRApWUVFIREFSQ1pYSnVNUXd3Q2dZRFZRUUtEQU5DU1ZReEREQUtCZ05WQkFzTUEwVlhTakVOTUFzR0ExVUVBd3dFClZHVnpkREVqTUNFR0NTcUdTSWIzRFFFSkFSWVVjM1Z3Y0c5eWRFQmlhWFF1WVdSdGFXNHVZMmd3VmpBUUJnY3EKaGtqT1BRSUJCZ1VyZ1FRQUNnTkNBQVRhc0ZoMEdLZWs1WTRKdXdnaTVIOEFrL3FmamtKQ3d6N1BYb0lVZWJnaQpzeTdUVlFMckltQlBVN2lnMDM3azBkb1V4aytYZEJLWDQzdi9yZEdZVUtmMW8xTXdVVEFkQmdOVkhRNEVGZ1FVCnVTS2lWSUdsRnpQdDdXd3Z1VGNicDNrckQ0UXdId1lEVlIwakJCZ3dGb0FVdVNLaVZJR2xGelB0N1d3dnVUY2IKcDNrckQ0UXdEd1lEVlIwVEFRSC9CQVV3QXdFQi96QUtCZ2dxaGtqT1BRUURBZ05JQURCRkFpQkRteEJUQ3BZawphN0hFeUFEWnN4d3p3b2h0TjBwNTd5QllMYjZzQ3B3ODhBSWhBSXpTUDdCV0tGWmNDSmI5ZmhwcjZaTXpJd0tlCkhhSWpIK2E4elV2Nk1PaW8KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=",
-    "vcap.services.ecdsa_dev.credentials.privateKey=LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JR0VBZ0VBTUJBR0J5cUdTTTQ5QWdFR0JTdUJCQUFLQkcwd2F3SUJBUVFnMkRsai9lNW5rRlBtTk1MVjd1NjQKenFuOHdSeVgrUTgyc045RDRSWXlvNjJoUkFOQ0FBVGFzRmgwR0tlazVZNEp1d2dpNUg4QWsvcWZqa0pDd3o3UApYb0lVZWJnaXN5N1RWUUxySW1CUFU3aWcwMzdrMGRvVXhrK1hkQktYNDN2L3JkR1lVS2YxCi0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K"
-})
+@TestPropertySource(properties = { "ws.app.source=org.dpppt.demo",
+		"vcap.services.ecdsa_dev.credentials.publicKey=LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNTRENDQWU2Z0F3SUJBZ0lVS3pEQlJIZlZVN2djRGZxUTBGUDFLTkJULzVJd0NnWUlLb1pJemowRUF3SXcKZXpFTE1Ba0dBMVVFQmhNQ1EwZ3hEVEFMQmdOVkJBZ01CRUpsY200eERUQUxCZ05WQkFjTUJFSmxjbTR4RERBSwpCZ05WQkFvTUEwSkpWREVNTUFvR0ExVUVDd3dEUlZkS01RMHdDd1lEVlFRRERBUlVaWE4wTVNNd0lRWUpLb1pJCmh2Y05BUWtCRmhSemRYQndiM0owUUdKcGRDNWhaRzFwYmk1amFEQWVGdzB5TURBME1qZ3hNakUwTlRGYUZ3MHkKTVRBME1qZ3hNakUwTlRGYU1Ic3hDekFKQmdOVkJBWVRBa05JTVEwd0N3WURWUVFJREFSQ1pYSnVNUTB3Q3dZRApWUVFIREFSQ1pYSnVNUXd3Q2dZRFZRUUtEQU5DU1ZReEREQUtCZ05WQkFzTUEwVlhTakVOTUFzR0ExVUVBd3dFClZHVnpkREVqTUNFR0NTcUdTSWIzRFFFSkFSWVVjM1Z3Y0c5eWRFQmlhWFF1WVdSdGFXNHVZMmd3VmpBUUJnY3EKaGtqT1BRSUJCZ1VyZ1FRQUNnTkNBQVRhc0ZoMEdLZWs1WTRKdXdnaTVIOEFrL3FmamtKQ3d6N1BYb0lVZWJnaQpzeTdUVlFMckltQlBVN2lnMDM3azBkb1V4aytYZEJLWDQzdi9yZEdZVUtmMW8xTXdVVEFkQmdOVkhRNEVGZ1FVCnVTS2lWSUdsRnpQdDdXd3Z1VGNicDNrckQ0UXdId1lEVlIwakJCZ3dGb0FVdVNLaVZJR2xGelB0N1d3dnVUY2IKcDNrckQ0UXdEd1lEVlIwVEFRSC9CQVV3QXdFQi96QUtCZ2dxaGtqT1BRUURBZ05JQURCRkFpQkRteEJUQ3BZawphN0hFeUFEWnN4d3p3b2h0TjBwNTd5QllMYjZzQ3B3ODhBSWhBSXpTUDdCV0tGWmNDSmI5ZmhwcjZaTXpJd0tlCkhhSWpIK2E4elV2Nk1PaW8KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=",
+		"vcap.services.ecdsa_dev.credentials.privateKey=LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JR0VBZ0VBTUJBR0J5cUdTTTQ5QWdFR0JTdUJCQUFLQkcwd2F3SUJBUVFnMkRsai9lNW5rRlBtTk1MVjd1NjQKenFuOHdSeVgrUTgyc045RDRSWXlvNjJoUkFOQ0FBVGFzRmgwR0tlazVZNEp1d2dpNUg4QWsvcWZqa0pDd3o3UApYb0lVZWJnaXN5N1RWUUxySW1CUFU3aWcwMzdrMGRvVXhrK1hkQktYNDN2L3JkR1lVS2YxCi0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K" })
 public class CloudControllerTestPEM {
-    protected MockMvc mockMvc;
+	protected MockMvc mockMvc;
 	@Autowired
 	private WebApplicationContext webApplicationContext;
 	protected ObjectMapper objectMapper;
 
-    @Autowired
-    private ResponseWrapperFilter filter;
-    //private  String publicKey = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEc6n1FNz6RnwNeNM9H+KxaPckrBxgKU799v+DTy8ivc1ZM3nDyXq5zU2AFXvgvLFzWxU9z9FCcDPGTcN7cvOyXw==";
-    private PublicKey publicKey;
+	@Autowired
+	private ResponseWrapperFilter filter;
+	// private String publicKey =
+	// "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEc6n1FNz6RnwNeNM9H+KxaPckrBxgKU799v+DTy8ivc1ZM3nDyXq5zU2AFXvgvLFzWxU9z9FCcDPGTcN7cvOyXw==";
+	private PublicKey publicKey;
+
 	@Before
 	public void setup() throws Exception {
-        this.publicKey = filter.getPublicKey();
+		this.publicKey = filter.getPublicKey();
 		this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).addFilter(filter, "/*").build();
 		this.objectMapper = new ObjectMapper(new JsonFactory());
 		this.objectMapper.registerModule(new JavaTimeModule());
-		
-    }
-    
-    @Test
-    public void testJWT() throws Exception {
-        
-        ExposeeRequest exposeeRequest = new ExposeeRequest();
-        exposeeRequest.setAuthData(new ExposeeAuthData());
-        exposeeRequest.setKeyDate(LocalDate.now().atStartOfDay().atOffset(ZoneOffset.UTC).toInstant().toEpochMilli());
-        exposeeRequest.setKey(Base64.getEncoder().encodeToString("test".getBytes("UTF-8")));
-        MockHttpServletResponse response = mockMvc.perform(post("/v1/exposed")
-                                                            .contentType(MediaType.APPLICATION_JSON)
-                                                            .header("User-Agent", "MockMVC")
-                                                            .content(json(exposeeRequest)))
-                .andExpect(status().is2xxSuccessful()).andReturn().getResponse();
-        response = mockMvc.perform(get("/v1/")).andExpect(status().is2xxSuccessful()).andReturn().getResponse();
-        String content = response.getContentAsString();
-        assertEquals("Hello from DP3T WS",content);
-        assertEquals("dp3t", response.getHeader("X-HELLO"));
-        String signature = response.getHeader("Signature");
-        Jwt jwt = Jwts.parserBuilder().setSigningKey(publicKey).build().parse(signature);
-        Claims claims = (Claims)jwt.getBody();
-        assertEquals("dp3t", claims.get("iss"));
-    }
+
+	}
+
+	@Test
+	public void testJWT() throws Exception {
+
+		ExposeeRequest exposeeRequest = new ExposeeRequest();
+		exposeeRequest.setAuthData(new ExposeeAuthData());
+		exposeeRequest.setKeyDate(LocalDate.now().atStartOfDay().atOffset(ZoneOffset.UTC).toInstant().toEpochMilli());
+		exposeeRequest.setKey(Base64.getEncoder().encodeToString("testKey16Bytes--".getBytes("UTF-8")));
+		MockHttpServletResponse response = mockMvc.perform(post("/v1/exposed").contentType(MediaType.APPLICATION_JSON)
+				.header("User-Agent", "MockMVC").content(json(exposeeRequest))).andExpect(status().is2xxSuccessful())
+				.andReturn().getResponse();
+		response = mockMvc.perform(get("/v1/")).andExpect(status().is2xxSuccessful()).andReturn().getResponse();
+		String content = response.getContentAsString();
+		assertEquals("Hello from DP3T WS", content);
+		assertEquals("dp3t", response.getHeader("X-HELLO"));
+		String signature = response.getHeader("Signature");
+		Jwt jwt = Jwts.parserBuilder().setSigningKey(publicKey).build().parse(signature);
+		Claims claims = (Claims) jwt.getBody();
+		assertEquals("dp3t", claims.get("iss"));
+	}
 
 	protected String json(Object o) throws IOException {
 		return objectMapper.writeValueAsString(o);
-    }
+	}
 }

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/controller/DPPPTControllerNoSecurityTest.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/controller/DPPPTControllerNoSecurityTest.java
@@ -10,152 +10,149 @@
 
 package org.dpppt.backend.sdk.ws.controller;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Base64;
 import java.util.Iterator;
 
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import org.dpppt.backend.sdk.model.ExposeeAuthData;
 import org.dpppt.backend.sdk.model.ExposeeRequest;
-
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class DPPPTControllerNoSecurityTest extends BaseControllerNoSecurityTest {
-    @Test
-    public void testJWT() throws Exception {
-        ExposeeRequest exposeeRequest = new ExposeeRequest();
-        exposeeRequest.setAuthData(new ExposeeAuthData());
-        exposeeRequest.setKeyDate(LocalDate.now().atStartOfDay().atOffset(ZoneOffset.UTC).toInstant().toEpochMilli());
-        exposeeRequest.setKey(Base64.getEncoder().encodeToString("test".getBytes("UTF-8")));
-        exposeeRequest.setIsFake(0);
-        MockHttpServletResponse response = mockMvc.perform(post("/v1/exposed")
-                                                            .contentType(MediaType.APPLICATION_JSON)
-                                                            .header("User-Agent", "MockMVC")
-                                                            .content(json(exposeeRequest)))
-                .andExpect(status().is2xxSuccessful()).andReturn().getResponse();
-    }
-    @Test
-    public void testJWTFake() throws Exception {
-        ExposeeRequest exposeeRequest = new ExposeeRequest();
-        exposeeRequest.setAuthData(new ExposeeAuthData());
-        exposeeRequest.setKeyDate(LocalDate.now().atStartOfDay().atOffset(ZoneOffset.UTC).toInstant().toEpochMilli());
-        exposeeRequest.setKey(Base64.getEncoder().encodeToString("test".getBytes("UTF-8")));
-        exposeeRequest.setIsFake(1);
-        MockHttpServletResponse response = mockMvc.perform(post("/v1/exposed")
-                                                            .contentType(MediaType.APPLICATION_JSON)
-                                                            .header("User-Agent", "MockMVC")
-                                                            .content(json(exposeeRequest)))
-                .andExpect(status().is2xxSuccessful()).andReturn().getResponse();
-    }
-    @Test
-    public void keyDateNotOlderThan21Days() throws Exception {
-        ExposeeRequest exposeeRequest = new ExposeeRequest();
-        exposeeRequest.setAuthData(new ExposeeAuthData());
-        exposeeRequest.setKeyDate(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).minusDays(22).toInstant().toEpochMilli());
-        exposeeRequest.setKey(Base64.getEncoder().encodeToString("test".getBytes("UTF-8")));
+	@Test
+	public void testJWT() throws Exception {
+		ExposeeRequest exposeeRequest = new ExposeeRequest();
+		exposeeRequest.setAuthData(new ExposeeAuthData());
+		exposeeRequest.setKeyDate(LocalDate.now().atStartOfDay().atOffset(ZoneOffset.UTC).toInstant().toEpochMilli());
+		exposeeRequest.setKey(Base64.getEncoder().encodeToString("testKey16Bytes--".getBytes("UTF-8")));
+		exposeeRequest.setIsFake(0);
+		MockHttpServletResponse response = mockMvc.perform(post("/v1/exposed").contentType(MediaType.APPLICATION_JSON)
+				.header("User-Agent", "MockMVC").content(json(exposeeRequest))).andExpect(status().is2xxSuccessful())
+				.andReturn().getResponse();
+	}
 
-        MockHttpServletResponse response = mockMvc.perform(post("/v1/exposed")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .header("User-Agent", "MockMVC")
-                    .content(json(exposeeRequest)))
-            .andExpect(status().is4xxClientError()).andReturn().getResponse();
-    }
-    @Test
-    public void keyDateNotInTheFuture() throws Exception {
-        ExposeeRequest exposeeRequest = new ExposeeRequest();
-        exposeeRequest.setAuthData(new ExposeeAuthData());
-        exposeeRequest.setKeyDate(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).plusMinutes(1).toInstant().toEpochMilli());
-        exposeeRequest.setKey(Base64.getEncoder().encodeToString("test".getBytes("UTF-8")));
+	@Test
+	public void testJWTFake() throws Exception {
+		ExposeeRequest exposeeRequest = new ExposeeRequest();
+		exposeeRequest.setAuthData(new ExposeeAuthData());
+		exposeeRequest.setKeyDate(LocalDate.now().atStartOfDay().atOffset(ZoneOffset.UTC).toInstant().toEpochMilli());
+		exposeeRequest.setKey(Base64.getEncoder().encodeToString("testKey16Bytes--".getBytes("UTF-8")));
+		exposeeRequest.setIsFake(1);
+		MockHttpServletResponse response = mockMvc.perform(post("/v1/exposed").contentType(MediaType.APPLICATION_JSON)
+				.header("User-Agent", "MockMVC").content(json(exposeeRequest))).andExpect(status().is2xxSuccessful())
+				.andReturn().getResponse();
+	}
 
-        MockHttpServletResponse response = mockMvc.perform(post("/v1/exposed")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .header("User-Agent", "MockMVC")
-                    .content(json(exposeeRequest)))
-            .andExpect(status().is4xxClientError()).andReturn().getResponse();
-    }
-    @Test
-    public void justNowShouldBeFine() throws Exception {
-        ExposeeRequest exposeeRequest = new ExposeeRequest();
-        exposeeRequest.setAuthData(new ExposeeAuthData());
-        exposeeRequest.setKeyDate(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).toInstant().toEpochMilli());
-        exposeeRequest.setKey(Base64.getEncoder().encodeToString("test".getBytes("UTF-8")));
+	@Test
+	public void keyDateNotOlderThan21Days() throws Exception {
+		ExposeeRequest exposeeRequest = new ExposeeRequest();
+		exposeeRequest.setAuthData(new ExposeeAuthData());
+		exposeeRequest.setKeyDate(
+				OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).minusDays(22).toInstant().toEpochMilli());
+		exposeeRequest.setKey(Base64.getEncoder().encodeToString("test".getBytes("UTF-8")));
 
-        MockHttpServletResponse response = mockMvc.perform(post("/v1/exposed")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .header("User-Agent", "MockMVC")
-                    .content(json(exposeeRequest)))
-            .andExpect(status().is2xxSuccessful()).andReturn().getResponse();
-    }
+		MockHttpServletResponse response = mockMvc
+				.perform(post("/v1/exposed").contentType(MediaType.APPLICATION_JSON).header("User-Agent", "MockMVC")
+						.content(json(exposeeRequest)))
+				.andExpect(status().is4xxClientError()).andReturn().getResponse();
+	}
 
-    @Autowired
-    ObjectMapper mapper;
+	@Test
+	public void keyDateNotInTheFuture() throws Exception {
+		ExposeeRequest exposeeRequest = new ExposeeRequest();
+		exposeeRequest.setAuthData(new ExposeeAuthData());
+		exposeeRequest.setKeyDate(
+				OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).plusMinutes(1).toInstant().toEpochMilli());
+		exposeeRequest.setKey(Base64.getEncoder().encodeToString("test".getBytes("UTF-8")));
 
-    @Test
-    public void testBucketsAndExposedResponse() throws Exception {
-        MockHttpServletResponse response = mockMvc.perform(get("/v1/buckets/2020-04-29")
-                                                            .contentType(MediaType.APPLICATION_JSON)
-                                                            .header("User-Agent", "MockMVC"))
-                                        .andExpect(status().is(200))
-                                        .andReturn().getResponse();
-        Long bucket = mapper.readTree(response.getContentAsString()).get("buckets").elements().next().asLong();
-        response = mockMvc.perform(get("/v1/exposed/" + bucket.toString()))
-                    .andExpect(status().is2xxSuccessful()).andReturn().getResponse();
-        assertEquals(response.getContentType(), "application/x-protobuf");
-        response = mockMvc.perform(get("/v1/exposedjson/" + bucket.toString()))
-        .andExpect(status().is2xxSuccessful()).andReturn().getResponse();
-        assertEquals(response.getContentType(), "application/json");
-    }
-    @Test
-    public void test400WhenNotModBatch() throws Exception {
-        MockHttpServletResponse response = mockMvc.perform(get("/v1/buckets/2020-04-29")
-                                                            .contentType(MediaType.APPLICATION_JSON)
-                                                            .header("User-Agent", "MockMVC"))
-                                        .andExpect(status().is(200))
-                                        .andReturn().getResponse();
-        Long bucket = mapper.readTree(response.getContentAsString()).get("buckets").elements().next().asLong() +1;
+		MockHttpServletResponse response = mockMvc
+				.perform(post("/v1/exposed").contentType(MediaType.APPLICATION_JSON).header("User-Agent", "MockMVC")
+						.content(json(exposeeRequest)))
+				.andExpect(status().is4xxClientError()).andReturn().getResponse();
+	}
 
-        response = mockMvc.perform(get("/v1/exposed/" + Long.toString(bucket)))
-                    .andExpect(status().isBadRequest()).andReturn().getResponse();
-        response = mockMvc.perform(get("/v1/exposedjson/" + Long.toString(bucket)))
-        .andExpect(status().isBadRequest()).andReturn().getResponse();
-    }
-    @Test
-    public void test404() throws Exception {
-        MockHttpServletResponse response = mockMvc.perform(get("/v1/buckets/2020-04-29")
-                                                            .contentType(MediaType.APPLICATION_JSON)
-                                                            .header("User-Agent", "MockMVC"))
-                                        .andExpect(status().is(200))
-                                        .andReturn().getResponse();
-        Iterator<JsonNode> buckets = mapper.readTree(response.getContentAsString()).get("buckets").elements();
-        Long first = buckets.next().asLong();
-        Long next = buckets.next().asLong();
-        Long batchLength = next-first;
-        long future = (long)Math.floor(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).plusDays(1).toInstant().toEpochMilli() / batchLength) * batchLength ;
-        long past = (long)Math.floor(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).minusYears(1).toInstant().toEpochMilli() / batchLength) * batchLength ;
+	@Test
+	public void justNowShouldBeFine() throws Exception {
+		ExposeeRequest exposeeRequest = new ExposeeRequest();
+		exposeeRequest.setAuthData(new ExposeeAuthData());
+		exposeeRequest
+				.setKeyDate(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).toInstant().toEpochMilli());
+		exposeeRequest.setKey(Base64.getEncoder().encodeToString("testKey16Bytes--".getBytes("UTF-8")));
 
-        response = mockMvc.perform(get("/v1/exposed/" + Long.toString(future)))
-        .andExpect(status().isNotFound()).andReturn().getResponse();
-        response = mockMvc.perform(get("/v1/exposedjson/" + Long.toString(future)))
-        .andExpect(status().isNotFound()).andReturn().getResponse();
+		MockHttpServletResponse response = mockMvc.perform(post("/v1/exposed").contentType(MediaType.APPLICATION_JSON)
+				.header("User-Agent", "MockMVC").content(json(exposeeRequest))).andExpect(status().is2xxSuccessful())
+				.andReturn().getResponse();
+	}
 
-        response = mockMvc.perform(get("/v1/exposed/" + Long.toString(past)))
-        .andExpect(status().isNotFound()).andReturn().getResponse();
-        response = mockMvc.perform(get("/v1/exposedjson/" + Long.toString(past)))
-        .andExpect(status().isNotFound()).andReturn().getResponse();
-    }
+	@Autowired
+	ObjectMapper mapper;
+
+	@Test
+	public void testBucketsAndExposedResponse() throws Exception {
+		MockHttpServletResponse response = mockMvc.perform(
+				get("/v1/buckets/2020-04-29").contentType(MediaType.APPLICATION_JSON).header("User-Agent", "MockMVC"))
+				.andExpect(status().is(200)).andReturn().getResponse();
+		Long bucket = mapper.readTree(response.getContentAsString()).get("buckets").elements().next().asLong();
+		response = mockMvc.perform(get("/v1/exposed/" + bucket.toString())).andExpect(status().is2xxSuccessful())
+				.andReturn().getResponse();
+		assertEquals(response.getContentType(), "application/x-protobuf");
+		response = mockMvc.perform(get("/v1/exposedjson/" + bucket.toString())).andExpect(status().is2xxSuccessful())
+				.andReturn().getResponse();
+		assertEquals(response.getContentType(), "application/json");
+	}
+
+	@Test
+	public void test400WhenNotModBatch() throws Exception {
+		MockHttpServletResponse response = mockMvc.perform(
+				get("/v1/buckets/2020-04-29").contentType(MediaType.APPLICATION_JSON).header("User-Agent", "MockMVC"))
+				.andExpect(status().is(200)).andReturn().getResponse();
+		Long bucket = mapper.readTree(response.getContentAsString()).get("buckets").elements().next().asLong() + 1;
+
+		response = mockMvc.perform(get("/v1/exposed/" + Long.toString(bucket))).andExpect(status().isBadRequest())
+				.andReturn().getResponse();
+		response = mockMvc.perform(get("/v1/exposedjson/" + Long.toString(bucket))).andExpect(status().isBadRequest())
+				.andReturn().getResponse();
+	}
+
+	@Test
+	public void test404() throws Exception {
+		MockHttpServletResponse response = mockMvc.perform(
+				get("/v1/buckets/2020-04-29").contentType(MediaType.APPLICATION_JSON).header("User-Agent", "MockMVC"))
+				.andExpect(status().is(200)).andReturn().getResponse();
+		Iterator<JsonNode> buckets = mapper.readTree(response.getContentAsString()).get("buckets").elements();
+		Long first = buckets.next().asLong();
+		Long next = buckets.next().asLong();
+		Long batchLength = next - first;
+		long future = (long) Math
+				.floor(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).plusDays(1).toInstant().toEpochMilli()
+						/ batchLength)
+				* batchLength;
+		long past = (long) Math.floor(
+				OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).minusYears(1).toInstant().toEpochMilli()
+						/ batchLength)
+				* batchLength;
+
+		response = mockMvc.perform(get("/v1/exposed/" + Long.toString(future))).andExpect(status().isNotFound())
+				.andReturn().getResponse();
+		response = mockMvc.perform(get("/v1/exposedjson/" + Long.toString(future))).andExpect(status().isNotFound())
+				.andReturn().getResponse();
+
+		response = mockMvc.perform(get("/v1/exposed/" + Long.toString(past))).andExpect(status().isNotFound())
+				.andReturn().getResponse();
+		response = mockMvc.perform(get("/v1/exposedjson/" + Long.toString(past))).andExpect(status().isNotFound())
+				.andReturn().getResponse();
+	}
 }

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/controller/DPPPTControllerTest.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/controller/DPPPTControllerTest.java
@@ -34,347 +34,307 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
 
-
-@SpringBootTest(properties =
-{
-    "ws.app.jwt.publickey=classpath://generated_pub.pem"
- })
+@SpringBootTest(properties = { "ws.app.jwt.publickey=classpath://generated_pub.pem" })
 public class DPPPTControllerTest extends BaseControllerTest {
-    @Test
-    public void testHello() throws Exception {
-        MockHttpServletResponse response = mockMvc.perform(get("/v1"))
-                .andExpect(status().is2xxSuccessful()).andReturn().getResponse();
+	@Test
+	public void testHello() throws Exception {
+		MockHttpServletResponse response = mockMvc.perform(get("/v1")).andExpect(status().is2xxSuccessful()).andReturn()
+				.getResponse();
 
-        assertNotNull(response);
-        assertEquals("Hello from DP3T WS", response.getContentAsString());
-    }
+		assertNotNull(response);
+		assertEquals("Hello from DP3T WS", response.getContentAsString());
+	}
 
-    @Test
-    public void testJWT() throws Exception {
-        ExposeeRequest exposeeRequest = new ExposeeRequest();
-        exposeeRequest.setAuthData(new ExposeeAuthData());
-        exposeeRequest.setKeyDate(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).toInstant().toEpochMilli());
-        exposeeRequest.setKey(Base64.getEncoder().encodeToString("test".getBytes("UTF-8")));
-        exposeeRequest.setIsFake(0);
-        String token = createToken(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).plusMinutes(5));
-        MockHttpServletResponse response = mockMvc.perform(post("/v1/exposed")
-                                                            .contentType(MediaType.APPLICATION_JSON)
-                                                            .header("Authorization", "Bearer " + token)
-                                                            .header("User-Agent", "MockMVC")
-                                                            .content(json(exposeeRequest)))
-                .andExpect(status().is2xxSuccessful()).andReturn().getResponse();
-        response = mockMvc.perform(post("/v1/exposed")
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .header("Authorization", "Bearer " + jwtToken)
-                                .header("User-Agent", "MockMVC")
-                                .content(json(exposeeRequest)))
-                .andExpect(status().is(401))
-                .andExpect(content().string(""))
-                .andReturn().getResponse();
+	@Test
+	public void testJWT() throws Exception {
+		ExposeeRequest exposeeRequest = new ExposeeRequest();
+		exposeeRequest.setAuthData(new ExposeeAuthData());
+		exposeeRequest
+				.setKeyDate(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).toInstant().toEpochMilli());
+		exposeeRequest.setKey(Base64.getEncoder().encodeToString("testKey16Bytes--".getBytes("UTF-8")));
+		exposeeRequest.setIsFake(0);
+		String token = createToken(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).plusMinutes(5));
+		MockHttpServletResponse response = mockMvc.perform(
+				post("/v1/exposed").contentType(MediaType.APPLICATION_JSON).header("Authorization", "Bearer " + token)
+						.header("User-Agent", "MockMVC").content(json(exposeeRequest)))
+				.andExpect(status().is2xxSuccessful()).andReturn().getResponse();
+		response = mockMvc
+				.perform(post("/v1/exposed").contentType(MediaType.APPLICATION_JSON)
+						.header("Authorization", "Bearer " + jwtToken).header("User-Agent", "MockMVC")
+						.content(json(exposeeRequest)))
+				.andExpect(status().is(401)).andExpect(content().string("")).andReturn().getResponse();
 
-       
-    }
-    @Test
-    public void testMultipleKeyUpload() throws Exception {
-        var requestList = new ExposeeRequestList();
-        var exposedKey1 = new ExposedKey();
-        exposedKey1.setKeyDate(OffsetDateTime.now(ZoneOffset.UTC).toInstant().toEpochMilli());
-        exposedKey1.setKey(Base64.getEncoder().encodeToString("test".getBytes("UTF-8")));
-        var exposedKey2 = new ExposedKey();
-        exposedKey2.setKeyDate(OffsetDateTime.now(ZoneOffset.UTC).minusDays(1).toInstant().toEpochMilli());
-        exposedKey2.setKey(Base64.getEncoder().encodeToString("test".getBytes("UTF-8")));
-        List<ExposedKey> exposedKeys = List.of(exposedKey1, exposedKey2);
-        requestList.setExposedKeys(exposedKeys);
-        requestList.setFake(0);
-        String token = createToken(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).plusMinutes(5));
-        MockHttpServletResponse response = mockMvc.perform(post("/v1/exposedlist")
-                                                            .contentType(MediaType.APPLICATION_JSON)
-                                                            .header("Authorization", "Bearer " + token)
-                                                            .header("User-Agent", "MockMVC")
-                                                            .content(json(requestList)))
-                .andExpect(status().is2xxSuccessful()).andReturn().getResponse();
-        response = mockMvc.perform(post("/v1/exposedlist")
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .header("Authorization", "Bearer " + jwtToken)
-                                .header("User-Agent", "MockMVC")
-                                .content(json(requestList)))
-                .andExpect(status().is(401))
-                .andExpect(content().string(""))
-                .andReturn().getResponse();
-    }
-    @Test
-    public void testMultipleKeyFakeUpload() throws Exception {
-        var requestList = new ExposeeRequestList();
-        var exposedKey1 = new ExposedKey();
-        exposedKey1.setKeyDate(OffsetDateTime.now(ZoneOffset.UTC).toInstant().toEpochMilli());
-        exposedKey1.setKey(Base64.getEncoder().encodeToString("test".getBytes("UTF-8")));
-        var exposedKey2 = new ExposedKey();
-        exposedKey2.setKeyDate(OffsetDateTime.now(ZoneOffset.UTC).minusDays(1).toInstant().toEpochMilli());
-        exposedKey2.setKey(Base64.getEncoder().encodeToString("test".getBytes("UTF-8")));
-        List<ExposedKey> exposedKeys = List.of(exposedKey1, exposedKey2);
-        requestList.setExposedKeys(exposedKeys);
-        requestList.setFake(1);
-        String token = createToken(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).plusMinutes(5));
-        MockHttpServletResponse response = mockMvc.perform(post("/v1/exposedlist")
-                                                            .contentType(MediaType.APPLICATION_JSON)
-                                                            .header("Authorization", "Bearer " + token)
-                                                            .header("User-Agent", "MockMVC")
-                                                            .content(json(requestList)))
-                .andExpect(status().is2xxSuccessful()).andReturn().getResponse();
-        response = mockMvc.perform(post("/v1/exposedlist")
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .header("Authorization", "Bearer " + jwtToken)
-                                .header("User-Agent", "MockMVC")
-                                .content(json(requestList)))
-                .andExpect(status().is(401))
-                .andExpect(content().string(""))
-                .andReturn().getResponse();
-    }
-    @Test
-    public void testMultipleKeyNonEmptyUpload() throws Exception {
-        var requestList = new ExposeeRequestList();
-        List<ExposedKey> exposedKeys = new ArrayList<ExposedKey>();
-        requestList.setExposedKeys(exposedKeys);
-        requestList.setFake(0);
-        String token = createToken(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).plusMinutes(5));
-        MockHttpServletResponse response = mockMvc.perform(post("/v1/exposedlist")
-                                                            .contentType(MediaType.APPLICATION_JSON)
-                                                            .header("Authorization", "Bearer " + token)
-                                                            .header("User-Agent", "MockMVC")
-                                                            .content(json(requestList)))
-                .andExpect(status().is(400)).andReturn().getResponse();
-        response = mockMvc.perform(post("/v1/exposedlist")
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .header("Authorization", "Bearer " + jwtToken)
-                                .header("User-Agent", "MockMVC")
-                                .content(json(requestList)))
-                .andExpect(status().is(401))
-                .andExpect(content().string(""))
-                .andReturn().getResponse();
-    }
-    @Test
-    public void testMultipleKeyNonNullUpload() throws Exception {
-        var requestList = new ExposeeRequestList();
-        List<ExposedKey> exposedKeys = new ArrayList<ExposedKey>();
-        requestList.setFake(0);
-        String token = createToken(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).plusMinutes(5));
-        MockHttpServletResponse response = mockMvc.perform(post("/v1/exposedlist")
-                                                            .contentType(MediaType.APPLICATION_JSON)
-                                                            .header("Authorization", "Bearer " + token)
-                                                            .header("User-Agent", "MockMVC")
-                                                            .content(json(requestList)))
-                .andExpect(status().is(400)).andReturn().getResponse();
-        response = mockMvc.perform(post("/v1/exposedlist")
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .header("Authorization", "Bearer " + jwtToken)
-                                .header("User-Agent", "MockMVC")
-                                .content(json(requestList)))
-                .andExpect(status().is(401))
-                .andExpect(content().string(""))
-                .andReturn().getResponse();
-    }
-    @Test
-    public void keyNeedsToBeBase64() throws Exception {
-        ExposeeRequest exposeeRequest = new ExposeeRequest();
-        exposeeRequest.setAuthData(new ExposeeAuthData());
-        exposeeRequest.setKeyDate(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).toInstant().toEpochMilli());
-        exposeeRequest.setKey("~ö$%^a#@");
-        exposeeRequest.setIsFake(1);
-        String token = createToken(true, OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).plusMinutes(5));
-        MockHttpServletResponse response  = mockMvc.perform(post("/v1/exposed")
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .header("Authorization", "Bearer " + token)
-                                .header("User-Agent", "MockMVC")
-                                .content(json(exposeeRequest)))
-                .andExpect(status().is(400)).andReturn().getResponse();
-    }
-    @Test
-    public void testJWTFake() throws Exception {
-        ExposeeRequest exposeeRequest = new ExposeeRequest();
-        exposeeRequest.setAuthData(new ExposeeAuthData());
-        exposeeRequest.setKeyDate(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).toInstant().toEpochMilli());
-        exposeeRequest.setKey(Base64.getEncoder().encodeToString("test".getBytes("UTF-8")));
-        exposeeRequest.setIsFake(1);
-        String token = createToken(true, OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).plusMinutes(5));
-        MockHttpServletResponse response  = mockMvc.perform(post("/v1/exposed")
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .header("Authorization", "Bearer " + token)
-                                .header("User-Agent", "MockMVC")
-                                .content(json(exposeeRequest)))
-                .andExpect(status().is2xxSuccessful()).andReturn().getResponse();
-        response = mockMvc.perform(post("/v1/exposed")
-                .contentType(MediaType.APPLICATION_JSON)
-                .header("Authorization", "Bearer " + jwtToken)
-                .header("User-Agent", "MockMVC")
-                .content(json(exposeeRequest)))
-        .andExpect(status().is(401))
-        .andExpect(content().string(""))
-        .andReturn().getResponse();
-    }
+	}
 
-    @Test
-    public void cannotUseKeyDateBeforeOnset() throws Exception {
-        ExposeeRequest exposeeRequest = new ExposeeRequest();
-        exposeeRequest.setAuthData(new ExposeeAuthData());
-        exposeeRequest.setKeyDate(LocalDate.now().minusDays(2).atStartOfDay().atOffset(ZoneOffset.UTC).toInstant().toEpochMilli());
-        exposeeRequest.setKey(Base64.getEncoder().encodeToString("test".getBytes("UTF-8")));
-        exposeeRequest.setIsFake(1);
-        String token = createToken(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).plusMinutes(5), LocalDate.now().format(DateTimeFormatter.ISO_DATE));
-        MockHttpServletResponse response  = mockMvc.perform(post("/v1/exposed")
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .header("Authorization", "Bearer " + token)
-                                .header("User-Agent", "MockMVC")
-                                .content(json(exposeeRequest)))
-                .andExpect(status().is(400)).andReturn().getResponse();
-    }
+	@Test
+	public void testMultipleKeyUpload() throws Exception {
+		var requestList = new ExposeeRequestList();
+		var exposedKey1 = new ExposedKey();
+		exposedKey1.setKeyDate(OffsetDateTime.now(ZoneOffset.UTC).toInstant().toEpochMilli());
+		exposedKey1.setKey(Base64.getEncoder().encodeToString("testKey16Bytes--".getBytes("UTF-8")));
+		var exposedKey2 = new ExposedKey();
+		exposedKey2.setKeyDate(OffsetDateTime.now(ZoneOffset.UTC).minusDays(1).toInstant().toEpochMilli());
+		exposedKey2.setKey(Base64.getEncoder().encodeToString("testKey16Bytes--".getBytes("UTF-8")));
+		List<ExposedKey> exposedKeys = List.of(exposedKey1, exposedKey2);
+		requestList.setExposedKeys(exposedKeys);
+		requestList.setFake(0);
+		String token = createToken(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).plusMinutes(5));
+		MockHttpServletResponse response = mockMvc.perform(post("/v1/exposedlist")
+				.contentType(MediaType.APPLICATION_JSON).header("Authorization", "Bearer " + token)
+				.header("User-Agent", "MockMVC").content(json(requestList))).andExpect(status().is2xxSuccessful())
+				.andReturn().getResponse();
+		response = mockMvc
+				.perform(post("/v1/exposedlist").contentType(MediaType.APPLICATION_JSON)
+						.header("Authorization", "Bearer " + jwtToken).header("User-Agent", "MockMVC")
+						.content(json(requestList)))
+				.andExpect(status().is(401)).andExpect(content().string("")).andReturn().getResponse();
+	}
 
-    @Test
-    public void cannotUseSameTokenTwice() throws Exception {
-        ExposeeRequest exposeeRequest = new ExposeeRequest();
-        exposeeRequest.setAuthData(new ExposeeAuthData());
-        exposeeRequest.setKeyDate(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).toInstant().toEpochMilli());
-        exposeeRequest.setKey(Base64.getEncoder().encodeToString("test".getBytes("UTF-8")));
-        exposeeRequest.setIsFake(0);
-        String token = createToken(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).plusMinutes(5));
+	@Test
+	public void testMultipleKeyFakeUpload() throws Exception {
+		var requestList = new ExposeeRequestList();
+		var exposedKey1 = new ExposedKey();
+		exposedKey1.setKeyDate(OffsetDateTime.now(ZoneOffset.UTC).toInstant().toEpochMilli());
+		exposedKey1.setKey(Base64.getEncoder().encodeToString("testKey16Bytes--".getBytes("UTF-8")));
+		var exposedKey2 = new ExposedKey();
+		exposedKey2.setKeyDate(OffsetDateTime.now(ZoneOffset.UTC).minusDays(1).toInstant().toEpochMilli());
+		exposedKey2.setKey(Base64.getEncoder().encodeToString("testKey16Bytes--".getBytes("UTF-8")));
+		List<ExposedKey> exposedKeys = List.of(exposedKey1, exposedKey2);
+		requestList.setExposedKeys(exposedKeys);
+		requestList.setFake(1);
+		String token = createToken(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).plusMinutes(5));
+		MockHttpServletResponse response = mockMvc.perform(post("/v1/exposedlist")
+				.contentType(MediaType.APPLICATION_JSON).header("Authorization", "Bearer " + token)
+				.header("User-Agent", "MockMVC").content(json(requestList))).andExpect(status().is2xxSuccessful())
+				.andReturn().getResponse();
+		response = mockMvc
+				.perform(post("/v1/exposedlist").contentType(MediaType.APPLICATION_JSON)
+						.header("Authorization", "Bearer " + jwtToken).header("User-Agent", "MockMVC")
+						.content(json(requestList)))
+				.andExpect(status().is(401)).andExpect(content().string("")).andReturn().getResponse();
+	}
 
-        MockHttpServletResponse response = mockMvc.perform(post("/v1/exposed")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .header("Authorization", "Bearer " + token)
-                    .header("User-Agent", "MockMVC")
-                    .content(json(exposeeRequest)))
-            .andExpect(status().is2xxSuccessful())
-            .andReturn().getResponse();
+	@Test
+	public void testMultipleKeyNonEmptyUpload() throws Exception {
+		var requestList = new ExposeeRequestList();
+		List<ExposedKey> exposedKeys = new ArrayList<ExposedKey>();
+		requestList.setExposedKeys(exposedKeys);
+		requestList.setFake(0);
+		String token = createToken(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).plusMinutes(5));
+		MockHttpServletResponse response = mockMvc.perform(post("/v1/exposedlist")
+				.contentType(MediaType.APPLICATION_JSON).header("Authorization", "Bearer " + token)
+				.header("User-Agent", "MockMVC").content(json(requestList))).andExpect(status().is(400)).andReturn()
+				.getResponse();
+		response = mockMvc
+				.perform(post("/v1/exposedlist").contentType(MediaType.APPLICATION_JSON)
+						.header("Authorization", "Bearer " + jwtToken).header("User-Agent", "MockMVC")
+						.content(json(requestList)))
+				.andExpect(status().is(401)).andExpect(content().string("")).andReturn().getResponse();
+	}
 
-        response = mockMvc.perform(post("/v1/exposed")
-                .contentType(MediaType.APPLICATION_JSON)
-                .header("Authorization", "Bearer " + token)
-                .header("User-Agent", "MockMVC")
-                .content(json(exposeeRequest)))
-        .andExpect(status().is(401))
-        .andExpect(content().string(""))
-        .andReturn().getResponse();
-    }
+	@Test
+	public void testMultipleKeyNonNullUpload() throws Exception {
+		var requestList = new ExposeeRequestList();
+		List<ExposedKey> exposedKeys = new ArrayList<ExposedKey>();
+		requestList.setFake(0);
+		String token = createToken(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).plusMinutes(5));
+		MockHttpServletResponse response = mockMvc.perform(post("/v1/exposedlist")
+				.contentType(MediaType.APPLICATION_JSON).header("Authorization", "Bearer " + token)
+				.header("User-Agent", "MockMVC").content(json(requestList))).andExpect(status().is(400)).andReturn()
+				.getResponse();
+		response = mockMvc
+				.perform(post("/v1/exposedlist").contentType(MediaType.APPLICATION_JSON)
+						.header("Authorization", "Bearer " + jwtToken).header("User-Agent", "MockMVC")
+						.content(json(requestList)))
+				.andExpect(status().is(401)).andExpect(content().string("")).andReturn().getResponse();
+	}
 
-    @Test
-    public void canUseSameTokenTwiceIfFake() throws Exception {
-        ExposeeRequest exposeeRequest = new ExposeeRequest();
-        exposeeRequest.setAuthData(new ExposeeAuthData());
-        exposeeRequest.setKeyDate(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).toInstant().toEpochMilli());
-        exposeeRequest.setKey(Base64.getEncoder().encodeToString("test".getBytes("UTF-8")));
-        exposeeRequest.setIsFake(1);
-        String token = createToken(true, OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).plusMinutes(5));
+	@Test
+	public void keyNeedsToBeBase64() throws Exception {
+		ExposeeRequest exposeeRequest = new ExposeeRequest();
+		exposeeRequest.setAuthData(new ExposeeAuthData());
+		exposeeRequest
+				.setKeyDate(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).toInstant().toEpochMilli());
+		exposeeRequest.setKey("~ö$%^a#@");
+		exposeeRequest.setIsFake(1);
+		String token = createToken(true, OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).plusMinutes(5));
+		MockHttpServletResponse response = mockMvc.perform(
+				post("/v1/exposed").contentType(MediaType.APPLICATION_JSON).header("Authorization", "Bearer " + token)
+						.header("User-Agent", "MockMVC").content(json(exposeeRequest)))
+				.andExpect(status().is(400)).andReturn().getResponse();
+	}
 
-        MockHttpServletResponse response = mockMvc.perform(post("/v1/exposed")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .header("Authorization", "Bearer " + token)
-                    .header("User-Agent", "MockMVC")
-                    .content(json(exposeeRequest)))
-            .andExpect(status().is2xxSuccessful()).andReturn().getResponse();
+	@Test
+	public void testJWTFake() throws Exception {
+		ExposeeRequest exposeeRequest = new ExposeeRequest();
+		exposeeRequest.setAuthData(new ExposeeAuthData());
+		exposeeRequest
+				.setKeyDate(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).toInstant().toEpochMilli());
+		exposeeRequest.setKey(Base64.getEncoder().encodeToString("testKey16Bytes--".getBytes("UTF-8")));
+		exposeeRequest.setIsFake(1);
+		String token = createToken(true, OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).plusMinutes(5));
+		MockHttpServletResponse response = mockMvc.perform(
+				post("/v1/exposed").contentType(MediaType.APPLICATION_JSON).header("Authorization", "Bearer " + token)
+						.header("User-Agent", "MockMVC").content(json(exposeeRequest)))
+				.andExpect(status().is2xxSuccessful()).andReturn().getResponse();
+		response = mockMvc
+				.perform(post("/v1/exposed").contentType(MediaType.APPLICATION_JSON)
+						.header("Authorization", "Bearer " + jwtToken).header("User-Agent", "MockMVC")
+						.content(json(exposeeRequest)))
+				.andExpect(status().is(401)).andExpect(content().string("")).andReturn().getResponse();
+	}
 
-        response = mockMvc.perform(post("/v1/exposed")
-                .contentType(MediaType.APPLICATION_JSON)
-                .header("Authorization", "Bearer " + token)
-                .header("User-Agent", "MockMVC")
-                .content(json(exposeeRequest)))
-        .andExpect(status().is2xxSuccessful()).andReturn().getResponse();
+	@Test
+	public void cannotUseKeyDateBeforeOnset() throws Exception {
+		ExposeeRequest exposeeRequest = new ExposeeRequest();
+		exposeeRequest.setAuthData(new ExposeeAuthData());
+		exposeeRequest.setKeyDate(
+				LocalDate.now().minusDays(2).atStartOfDay().atOffset(ZoneOffset.UTC).toInstant().toEpochMilli());
+		exposeeRequest.setKey(Base64.getEncoder().encodeToString("test".getBytes("UTF-8")));
+		exposeeRequest.setIsFake(1);
+		String token = createToken(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).plusMinutes(5),
+				LocalDate.now().format(DateTimeFormatter.ISO_DATE));
+		MockHttpServletResponse response = mockMvc.perform(
+				post("/v1/exposed").contentType(MediaType.APPLICATION_JSON).header("Authorization", "Bearer " + token)
+						.header("User-Agent", "MockMVC").content(json(exposeeRequest)))
+				.andExpect(status().is(400)).andReturn().getResponse();
+	}
 
+	@Test
+	public void cannotUseSameTokenTwice() throws Exception {
+		ExposeeRequest exposeeRequest = new ExposeeRequest();
+		exposeeRequest.setAuthData(new ExposeeAuthData());
+		exposeeRequest
+				.setKeyDate(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).toInstant().toEpochMilli());
+		exposeeRequest.setKey(Base64.getEncoder().encodeToString("testKey16Bytes--".getBytes("UTF-8")));
+		exposeeRequest.setIsFake(0);
+		String token = createToken(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).plusMinutes(5));
 
-    }
+		MockHttpServletResponse response = mockMvc.perform(
+				post("/v1/exposed").contentType(MediaType.APPLICATION_JSON).header("Authorization", "Bearer " + token)
+						.header("User-Agent", "MockMVC").content(json(exposeeRequest)))
+				.andExpect(status().is2xxSuccessful()).andReturn().getResponse();
 
-    @Test
-    public void cannotUseExpiredToken() throws Exception {
-        ExposeeRequest exposeeRequest = new ExposeeRequest();
-        exposeeRequest.setAuthData(new ExposeeAuthData());
-        exposeeRequest.setKeyDate(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).toInstant().toEpochMilli());
-        exposeeRequest.setKey(Base64.getEncoder().encodeToString("test".getBytes("UTF-8")));
-        exposeeRequest.setIsFake(0);
-        String token = createToken(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).minusMinutes(5));
+		response = mockMvc
+				.perform(post("/v1/exposed").contentType(MediaType.APPLICATION_JSON)
+						.header("Authorization", "Bearer " + token).header("User-Agent", "MockMVC")
+						.content(json(exposeeRequest)))
+				.andExpect(status().is(401)).andExpect(content().string("")).andReturn().getResponse();
+	}
 
-        MockHttpServletResponse response = mockMvc.perform(post("/v1/exposed")
-                .contentType(MediaType.APPLICATION_JSON)
-                .header("Authorization", "Bearer " + token)
-                .header("User-Agent", "MockMVC")
-                .content(json(exposeeRequest)))
-        .andExpect(status().is4xxClientError()).andReturn().getResponse();
-    }
-    @Test
-    public void cannotUseKeyDateInFuture() throws Exception {
-        ExposeeRequest exposeeRequest = new ExposeeRequest();
-        exposeeRequest.setAuthData(new ExposeeAuthData());
-        exposeeRequest.setKeyDate(OffsetDateTime.now().plusDays(2).withOffsetSameInstant(ZoneOffset.UTC).toInstant().toEpochMilli());
-        exposeeRequest.setKey(Base64.getEncoder().encodeToString("test".getBytes("UTF-8")));
-        exposeeRequest.setIsFake(0);
-        String token = createToken(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).plusMinutes(5));
+	@Test
+	public void canUseSameTokenTwiceIfFake() throws Exception {
+		ExposeeRequest exposeeRequest = new ExposeeRequest();
+		exposeeRequest.setAuthData(new ExposeeAuthData());
+		exposeeRequest
+				.setKeyDate(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).toInstant().toEpochMilli());
+		exposeeRequest.setKey(Base64.getEncoder().encodeToString("testKey16Bytes--".getBytes("UTF-8")));
+		exposeeRequest.setIsFake(1);
+		String token = createToken(true, OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).plusMinutes(5));
 
-        MockHttpServletResponse response = mockMvc.perform(post("/v1/exposed")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .header("Authorization", "Bearer " + token)
-                    .header("User-Agent", "MockMVC")
-                    .content(json(exposeeRequest)))
-            .andExpect(status().is4xxClientError()).andReturn().getResponse();
-    }
-    @Test
-    public void keyDateNotOlderThan21Days() throws Exception {
-        ExposeeRequest exposeeRequest = new ExposeeRequest();
-        exposeeRequest.setAuthData(new ExposeeAuthData());
-        exposeeRequest.setKeyDate(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).minusDays(22).toInstant().toEpochMilli());
-        exposeeRequest.setKey(Base64.getEncoder().encodeToString("test".getBytes("UTF-8")));
-        exposeeRequest.setIsFake(0);
-        String token = createToken(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).plusMinutes(5), "2020-01-01");
+		MockHttpServletResponse response = mockMvc.perform(
+				post("/v1/exposed").contentType(MediaType.APPLICATION_JSON).header("Authorization", "Bearer " + token)
+						.header("User-Agent", "MockMVC").content(json(exposeeRequest)))
+				.andExpect(status().is2xxSuccessful()).andReturn().getResponse();
 
-        MockHttpServletResponse response = mockMvc.perform(post("/v1/exposed")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .header("Authorization", "Bearer " + token)
-                    .header("User-Agent", "MockMVC")
-                    .content(json(exposeeRequest)))
-            .andExpect(status().is4xxClientError()).andReturn().getResponse();
-    }
+		response = mockMvc.perform(
+				post("/v1/exposed").contentType(MediaType.APPLICATION_JSON).header("Authorization", "Bearer " + token)
+						.header("User-Agent", "MockMVC").content(json(exposeeRequest)))
+				.andExpect(status().is2xxSuccessful()).andReturn().getResponse();
 
-    @Test
-    public void cannotUseTokenWithWrongScope() throws Exception {
-        ExposeeRequest exposeeRequest = new ExposeeRequest();
-        exposeeRequest.setAuthData(new ExposeeAuthData());
-        exposeeRequest.setKeyDate(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).toInstant().toEpochMilli());
-        exposeeRequest.setKey(Base64.getEncoder().encodeToString("test".getBytes("UTF-8")));
-        exposeeRequest.setIsFake(0);
-        String token = createTokenWithScope(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).plusMinutes(5), "not-exposed");
+	}
 
-        MockHttpServletResponse response = mockMvc.perform(post("/v1/exposed")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .header("Authorization", "Bearer " + token)
-                    .header("User-Agent", "MockMVC")
-                    .content(json(exposeeRequest)))
-            .andExpect(status().is(403))
-            .andExpect(content().string(""))
-            .andReturn().getResponse();
+	@Test
+	public void cannotUseExpiredToken() throws Exception {
+		ExposeeRequest exposeeRequest = new ExposeeRequest();
+		exposeeRequest.setAuthData(new ExposeeAuthData());
+		exposeeRequest
+				.setKeyDate(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).toInstant().toEpochMilli());
+		exposeeRequest.setKey(Base64.getEncoder().encodeToString("test".getBytes("UTF-8")));
+		exposeeRequest.setIsFake(0);
+		String token = createToken(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).minusMinutes(5));
 
-        // Also for a 403 response, the token cannot be used a 2nd time
-        response = mockMvc.perform(post("/v1/exposed")
-                .contentType(MediaType.APPLICATION_JSON)
-                .header("Authorization", "Bearer " + token)
-                .header("User-Agent", "MockMVC")
-                .content(json(exposeeRequest)))
-        .andExpect(status().is(401))
-        .andExpect(content().string(""))
-        .andReturn().getResponse();
-    }
+		MockHttpServletResponse response = mockMvc
+				.perform(post("/v1/exposed").contentType(MediaType.APPLICATION_JSON)
+						.header("Authorization", "Bearer " + token).header("User-Agent", "MockMVC")
+						.content(json(exposeeRequest)))
+				.andExpect(status().is4xxClientError()).andReturn().getResponse();
+	}
 
-    @Test
-    public void cannotUsedLongLivedToken() throws Exception {
-        ExposeeRequest exposeeRequest = new ExposeeRequest();
-        exposeeRequest.setAuthData(new ExposeeAuthData());
-        exposeeRequest.setKeyDate(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).toInstant().toEpochMilli());
-        exposeeRequest.setKey(Base64.getEncoder().encodeToString("test".getBytes("UTF-8")));
-        exposeeRequest.setIsFake(0);
-        String token = createToken(OffsetDateTime.now(ZoneOffset.UTC).plusDays(90)); // very late expiration date
-        MockHttpServletResponse response = mockMvc.perform(post("/v1/exposed")
-                                                            .contentType(MediaType.APPLICATION_JSON)
-                                                            .header("Authorization", "Bearer " + token)
-                                                            .header("User-Agent", "MockMVC")
-                                                            .content(json(exposeeRequest)))
-                .andExpect(status().is(401))
-                .andExpect(content().string(""))
-                .andReturn().getResponse();
-    }
+	@Test
+	public void cannotUseKeyDateInFuture() throws Exception {
+		ExposeeRequest exposeeRequest = new ExposeeRequest();
+		exposeeRequest.setAuthData(new ExposeeAuthData());
+		exposeeRequest.setKeyDate(
+				OffsetDateTime.now().plusDays(2).withOffsetSameInstant(ZoneOffset.UTC).toInstant().toEpochMilli());
+		exposeeRequest.setKey(Base64.getEncoder().encodeToString("test".getBytes("UTF-8")));
+		exposeeRequest.setIsFake(0);
+		String token = createToken(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).plusMinutes(5));
+
+		MockHttpServletResponse response = mockMvc
+				.perform(post("/v1/exposed").contentType(MediaType.APPLICATION_JSON)
+						.header("Authorization", "Bearer " + token).header("User-Agent", "MockMVC")
+						.content(json(exposeeRequest)))
+				.andExpect(status().is4xxClientError()).andReturn().getResponse();
+	}
+
+	@Test
+	public void keyDateNotOlderThan21Days() throws Exception {
+		ExposeeRequest exposeeRequest = new ExposeeRequest();
+		exposeeRequest.setAuthData(new ExposeeAuthData());
+		exposeeRequest.setKeyDate(
+				OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).minusDays(22).toInstant().toEpochMilli());
+		exposeeRequest.setKey(Base64.getEncoder().encodeToString("test".getBytes("UTF-8")));
+		exposeeRequest.setIsFake(0);
+		String token = createToken(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).plusMinutes(5),
+				"2020-01-01");
+
+		MockHttpServletResponse response = mockMvc
+				.perform(post("/v1/exposed").contentType(MediaType.APPLICATION_JSON)
+						.header("Authorization", "Bearer " + token).header("User-Agent", "MockMVC")
+						.content(json(exposeeRequest)))
+				.andExpect(status().is4xxClientError()).andReturn().getResponse();
+	}
+
+	@Test
+	public void cannotUseTokenWithWrongScope() throws Exception {
+		ExposeeRequest exposeeRequest = new ExposeeRequest();
+		exposeeRequest.setAuthData(new ExposeeAuthData());
+		exposeeRequest
+				.setKeyDate(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).toInstant().toEpochMilli());
+		exposeeRequest.setKey(Base64.getEncoder().encodeToString("test".getBytes("UTF-8")));
+		exposeeRequest.setIsFake(0);
+		String token = createTokenWithScope(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).plusMinutes(5),
+				"not-exposed");
+
+		MockHttpServletResponse response = mockMvc
+				.perform(post("/v1/exposed").contentType(MediaType.APPLICATION_JSON)
+						.header("Authorization", "Bearer " + token).header("User-Agent", "MockMVC")
+						.content(json(exposeeRequest)))
+				.andExpect(status().is(403)).andExpect(content().string("")).andReturn().getResponse();
+
+		// Also for a 403 response, the token cannot be used a 2nd time
+		response = mockMvc
+				.perform(post("/v1/exposed").contentType(MediaType.APPLICATION_JSON)
+						.header("Authorization", "Bearer " + token).header("User-Agent", "MockMVC")
+						.content(json(exposeeRequest)))
+				.andExpect(status().is(401)).andExpect(content().string("")).andReturn().getResponse();
+	}
+
+	@Test
+	public void cannotUsedLongLivedToken() throws Exception {
+		ExposeeRequest exposeeRequest = new ExposeeRequest();
+		exposeeRequest.setAuthData(new ExposeeAuthData());
+		exposeeRequest
+				.setKeyDate(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).toInstant().toEpochMilli());
+		exposeeRequest.setKey(Base64.getEncoder().encodeToString("test".getBytes("UTF-8")));
+		exposeeRequest.setIsFake(0);
+		String token = createToken(OffsetDateTime.now(ZoneOffset.UTC).plusDays(90)); // very late expiration date
+		MockHttpServletResponse response = mockMvc
+				.perform(post("/v1/exposed").contentType(MediaType.APPLICATION_JSON)
+						.header("Authorization", "Bearer " + token).header("User-Agent", "MockMVC")
+						.content(json(exposeeRequest)))
+				.andExpect(status().is(401)).andExpect(content().string("")).andReturn().getResponse();
+	}
 
 }

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/controller/DPPPTControllerTest.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/controller/DPPPTControllerTest.java
@@ -302,7 +302,7 @@ public class DPPPTControllerTest extends BaseControllerTest {
 		exposeeRequest.setAuthData(new ExposeeAuthData());
 		exposeeRequest
 				.setKeyDate(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).toInstant().toEpochMilli());
-		exposeeRequest.setKey(Base64.getEncoder().encodeToString("test".getBytes("UTF-8")));
+		exposeeRequest.setKey(Base64.getEncoder().encodeToString("testKey16Bytes--".getBytes("UTF-8")));
 		exposeeRequest.setIsFake(0);
 		String token = createTokenWithScope(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).plusMinutes(5),
 				"not-exposed");


### PR DESCRIPTION
Backend needs to validate the exposed key size before storage into the database in order to avoid serving invalid keys to clients (or other kind of attacks).

As per DP3T specification the key size is 32 bytes but Google/Apple algorithm is different and generates 16 bytes keys so it is required to accept both 16 and 32 bytes keys and reject all other size.
Correct ?