### PR TITLE
Fix warnings reported by CI Fuzz

### DIFF
--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/DPPPTController.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/DPPPTController.java
@@ -159,7 +159,7 @@ public class DPPPTController {
 	@GetMapping(value = "/exposedjson/{batchReleaseTime}", produces = "application/json")
 	public @ResponseBody ResponseEntity<ExposedOverview> getExposedByDayDate(@PathVariable Long batchReleaseTime,
 			WebRequest request) {
-		if (batchReleaseTime % batchLength != 0) {
+		if (batchReleaseTime == null || batchReleaseTime % batchLength != 0) {
 			return ResponseEntity.badRequest().build();
 		}
 		if (batchReleaseTime > OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).toInstant().toEpochMilli()) {
@@ -187,7 +187,7 @@ public class DPPPTController {
 	@GetMapping(value = "/exposed/{batchReleaseTime}", produces = "application/x-protobuf")
 	public @ResponseBody ResponseEntity<Exposed.ProtoExposedList> getExposedByBatch(@PathVariable Long batchReleaseTime,
 			WebRequest request) {
-		if (batchReleaseTime % batchLength != 0) {
+		if (batchReleaseTime == null || batchReleaseTime % batchLength != 0) {
 			return ResponseEntity.badRequest().build();
 		}
 		if (batchReleaseTime > OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).toInstant().toEpochMilli()) {

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/DPPPTController.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/DPPPTController.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import javax.validation.Valid;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.dpppt.backend.sdk.data.DPPPTDataService;
 import org.dpppt.backend.sdk.data.EtagGeneratorInterface;
 import org.dpppt.backend.sdk.model.BucketList;
@@ -35,6 +36,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -233,15 +235,10 @@ public class DPPPTController {
 		return ResponseEntity.ok(list);
 	}
 
-	@ExceptionHandler(IllegalArgumentException.class)
+	@ExceptionHandler({IllegalArgumentException.class, InvalidDateException.class, JsonProcessingException.class,
+			MethodArgumentNotValidException.class})
 	@ResponseStatus(HttpStatus.BAD_REQUEST)
 	public ResponseEntity<Object> invalidArguments() {
-		return ResponseEntity.badRequest().build();
-	}
-
-	@ExceptionHandler(InvalidDateException.class)
-	@ResponseStatus(HttpStatus.BAD_REQUEST)
-	public ResponseEntity<Object> invalidDate() {
 		return ResponseEntity.badRequest().build();
 	}
 

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/DPPPTController.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/DPPPTController.java
@@ -130,6 +130,9 @@ public class DPPPTController {
 
 		List<Exposee> exposees = new ArrayList<>();
 		for (var exposedKey : exposeeRequests.getExposedKeys()) {
+			if (exposedKey == null) {
+				return ResponseEntity.badRequest().build();
+			}
 			if (!isValidBase64Key(exposedKey.getKey())) {
 				return new ResponseEntity<>("No valid base64 key", HttpStatus.BAD_REQUEST);
 			}

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/DPPPTController.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/DPPPTController.java
@@ -14,6 +14,7 @@ import java.time.Duration;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
@@ -236,7 +237,7 @@ public class DPPPTController {
 	}
 
 	@ExceptionHandler({IllegalArgumentException.class, InvalidDateException.class, JsonProcessingException.class,
-			MethodArgumentNotValidException.class})
+			MethodArgumentNotValidException.class, DateTimeParseException.class})
 	@ResponseStatus(HttpStatus.BAD_REQUEST)
 	public ResponseEntity<Object> invalidArguments() {
 		return ResponseEntity.badRequest().build();

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/DPPPTController.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/DPPPTController.java
@@ -223,6 +223,9 @@ public class DPPPTController {
 	@GetMapping(value = "/buckets/{dayDateStr}", produces = "application/json")
 	public @ResponseBody ResponseEntity<BucketList> getListOfBuckets(@PathVariable String dayDateStr) {
 		OffsetDateTime day = LocalDate.parse(dayDateStr).atStartOfDay().atOffset(ZoneOffset.UTC);
+		if (day.toEpochSecond() < 0) {
+			return ResponseEntity.badRequest().build();
+		}
 		OffsetDateTime currentBucket = day;
 		OffsetDateTime now = OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC);
 		List<Long> bucketList = new ArrayList<>();


### PR DESCRIPTION
Hi,

I did a quick scan using the automated testing tool CI Fuzz by [Code Intelligence](https://www.code-intelligence.com/) which came up with a few warnings which are fixed in this PR.

The response message for the POST controllers contains the full error message from the json parser including unsanitized HTML characters. This _could_ lead to successful XSS attacks if the API is included for example in a web frontent. Even if this is not the case right now it is easiest to prevent in the backend. With this PR a generic 400 response is returned for these cases.

Multiple unhandled exceptions have also been addressed explicitly.