### PR TITLE
Load key pair from PEM

### DIFF
--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/security/KeyVault.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/security/KeyVault.java
@@ -120,10 +120,9 @@ public class KeyVault {
 		this.pairVault.put(pair.pairKey, pair.keyPair);
 	}
 
-	private KeyPair loadKeyPairFromString(KeyVaultEntry entry)
-			throws PrivateKeyNoSuitableEncodingFoundException, PublicKeyNoSuitableEncodingFoundException {
-		PrivateKey privateKey = loadPrivateKey(entry.privatePart, entry.algorithm);
-		PublicKey publicKey = loadPublicKey(entry.publicPart, entry.algorithm);
+	private KeyPair loadKeyPairFromString(KeyVaultEntry entry) {
+		PrivateKey privateKey = loadPrivateKeyFromPem(entry.privatePart, entry.algorithm);
+		PublicKey publicKey = loadPublicKeyFromPem(entry.publicPart, entry.algorithm);
 
 		return new KeyPair(publicKey, privateKey);
 	}


### PR DESCRIPTION
This way key pair generated by GenerateKeyPairEC.java works. Otherwise, both GenerateKeyPairEC.java and GenerateKeyPair.java are incompatible with current code.