### PR TITLE
Fix warnings reported by CI Fuzz

### DIFF
--- a/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/DPPPTDataService.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/DPPPTDataService.java
@@ -40,7 +40,7 @@ public interface DPPPTDataService {
 	 * @param batchLength
 	 * @return
 	 */
-	int getMaxExposedIdForBatchReleaseTime(Long batchReleaseTime, long batchLength);
+	int getMaxExposedIdForBatchReleaseTime(long batchReleaseTime, long batchLength);
 
 	/**
 	 * Returns all exposees for the given batch.
@@ -49,7 +49,7 @@ public interface DPPPTDataService {
 	 * @param batchLength
 	 * @return
 	 */
-	List<Exposee> getSortedExposedForBatchReleaseTime(Long batchReleaseTime, long batchLength);
+	List<Exposee> getSortedExposedForBatchReleaseTime(long batchReleaseTime, long batchLength);
 
 	/**
 	 * deletes entries older than retentionperiod

--- a/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/JDBCDPPPTDataServiceImpl.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/JDBCDPPPTDataServiceImpl.java
@@ -82,7 +82,7 @@ public class JDBCDPPPTDataServiceImpl implements DPPPTDataService {
 
 	@Override
 	@Transactional(readOnly = true)
-	public int getMaxExposedIdForBatchReleaseTime(Long batchReleaseTime, long batchLength) {
+	public int getMaxExposedIdForBatchReleaseTime(long batchReleaseTime, long batchLength) {
 		MapSqlParameterSource params = new MapSqlParameterSource();
 		params.addValue("batchReleaseTime", Date.from(Instant.ofEpochMilli(batchReleaseTime)));
 		params.addValue("startBatch", Date.from(Instant.ofEpochMilli(batchReleaseTime - batchLength)));
@@ -97,7 +97,7 @@ public class JDBCDPPPTDataServiceImpl implements DPPPTDataService {
 
 	@Override
 	@Transactional(readOnly = true)
-	public List<Exposee> getSortedExposedForBatchReleaseTime(Long batchReleaseTime, long batchLength) {
+	public List<Exposee> getSortedExposedForBatchReleaseTime(long batchReleaseTime, long batchLength) {
 		String sql = "select pk_exposed_id, key, key_date from t_exposed where received_at >= :startBatch and received_at < :batchReleaseTime order by pk_exposed_id desc";
 		MapSqlParameterSource params = new MapSqlParameterSource();
 		params.addValue("batchReleaseTime", Date.from(Instant.ofEpochMilli(batchReleaseTime)));

--- a/dpppt-backend-sdk/dpppt-backend-sdk-model/src/main/java/org/dpppt/backend/sdk/model/ExposeeRequestList.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-model/src/main/java/org/dpppt/backend/sdk/model/ExposeeRequestList.java
@@ -8,7 +8,7 @@ import javax.validation.constraints.NotNull;
 public class ExposeeRequestList {
     @NotNull
     @NotEmpty
-    List<ExposedKey> exposedKeys;
+    List<@NotNull ExposedKey> exposedKeys;
 
     private Integer fake = 0;
 

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/DPPPTController.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/DPPPTController.java
@@ -128,6 +128,9 @@ public class DPPPTController {
 
 		List<Exposee> exposees = new ArrayList<>();
 		for (var exposedKey : exposeeRequests.getExposedKeys()) {
+			if (exposedKey == null) {
+				return ResponseEntity.badRequest().build();
+			}
 			if (!validationUtils.isValidBase64Key(exposedKey.getKey())) {
 				return new ResponseEntity<>("No valid base64 key", HttpStatus.BAD_REQUEST);
 			}

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/DPPPTController.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/DPPPTController.java
@@ -156,7 +156,7 @@ public class DPPPTController {
 
 	@CrossOrigin(origins = { "https://editor.swagger.io" })
 	@GetMapping(value = "/exposedjson/{batchReleaseTime}", produces = "application/json")
-	public @ResponseBody ResponseEntity<ExposedOverview> getExposedByDayDate(@PathVariable Long batchReleaseTime,
+	public @ResponseBody ResponseEntity<ExposedOverview> getExposedByDayDate(@PathVariable long batchReleaseTime,
 			WebRequest request) throws BadBatchReleaseTimeException{
 		if(!validationUtils.isValidBatchReleaseTime(batchReleaseTime)) {
 			return ResponseEntity.notFound().build();
@@ -166,12 +166,12 @@ public class DPPPTController {
 		ExposedOverview overview = new ExposedOverview(exposeeList);
 		overview.setBatchReleaseTime(batchReleaseTime);
 		return ResponseEntity.ok().cacheControl(CacheControl.maxAge(Duration.ofMinutes(exposedListCacheContol)))
-				.header("X-BATCH-RELEASE-TIME", batchReleaseTime.toString()).body(overview);
+				.header("X-BATCH-RELEASE-TIME", Long.toString(batchReleaseTime)).body(overview);
 	}
 
 	@CrossOrigin(origins = { "https://editor.swagger.io" })
 	@GetMapping(value = "/exposed/{batchReleaseTime}", produces = "application/x-protobuf")
-	public @ResponseBody ResponseEntity<Exposed.ProtoExposedList> getExposedByBatch(@PathVariable Long batchReleaseTime,
+	public @ResponseBody ResponseEntity<Exposed.ProtoExposedList> getExposedByBatch(@PathVariable long batchReleaseTime,
 			WebRequest request) throws BadBatchReleaseTimeException {
 		if(!validationUtils.isValidBatchReleaseTime(batchReleaseTime)) {
 			return ResponseEntity.notFound().build();
@@ -189,7 +189,7 @@ public class DPPPTController {
 				.setBatchReleaseTime(batchReleaseTime).build();
 
 		return ResponseEntity.ok().cacheControl(CacheControl.maxAge(Duration.ofMinutes(exposedListCacheContol)))
-				.header("X-BATCH-RELEASE-TIME", batchReleaseTime.toString()).body(protoExposee);
+				.header("X-BATCH-RELEASE-TIME", Long.toString(batchReleaseTime)).body(protoExposee);
 	}
 
 	@CrossOrigin(origins = { "https://editor.swagger.io" })

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/DPPPTController.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/DPPPTController.java
@@ -14,6 +14,7 @@ import java.time.Duration;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
@@ -209,7 +210,7 @@ public class DPPPTController {
 	}
 
 	@ExceptionHandler({IllegalArgumentException.class, InvalidDateException.class, JsonProcessingException.class,
-			MethodArgumentNotValidException.class, BadBatchReleaseTimeException.class})
+			MethodArgumentNotValidException.class, BadBatchReleaseTimeException.class, DateTimeParseException.class})
 	@ResponseStatus(HttpStatus.BAD_REQUEST)
 	public ResponseEntity<Object> invalidArguments() {
 		return ResponseEntity.badRequest().build();

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/DPPPTController.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/DPPPTController.java
@@ -196,6 +196,9 @@ public class DPPPTController {
 	@GetMapping(value = "/buckets/{dayDateStr}", produces = "application/json")
 	public @ResponseBody ResponseEntity<BucketList> getListOfBuckets(@PathVariable String dayDateStr) {
 		OffsetDateTime day = LocalDate.parse(dayDateStr).atStartOfDay().atOffset(ZoneOffset.UTC);
+		if (day.toEpochSecond() < 0) {
+			return ResponseEntity.badRequest().build();
+		}
 		OffsetDateTime currentBucket = day;
 		OffsetDateTime now = OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC);
 		List<Long> bucketList = new ArrayList<>();

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/DPPPTController.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/DPPPTController.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import javax.validation.Valid;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.dpppt.backend.sdk.data.DPPPTDataService;
 import org.dpppt.backend.sdk.model.BucketList;
 import org.dpppt.backend.sdk.model.ExposedOverview;
@@ -36,6 +37,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -158,7 +160,7 @@ public class DPPPTController {
 		if(!validationUtils.isValidBatchReleaseTime(batchReleaseTime)) {
 			return ResponseEntity.notFound().build();
 		}
-		
+
 		List<Exposee> exposeeList = dataService.getSortedExposedForBatchReleaseTime(batchReleaseTime, batchLength);
 		ExposedOverview overview = new ExposedOverview(exposeeList);
 		overview.setBatchReleaseTime(batchReleaseTime);
@@ -206,20 +208,10 @@ public class DPPPTController {
 		return ResponseEntity.ok(list);
 	}
 
-	@ExceptionHandler(IllegalArgumentException.class)
+	@ExceptionHandler({IllegalArgumentException.class, InvalidDateException.class, JsonProcessingException.class,
+			MethodArgumentNotValidException.class, BadBatchReleaseTimeException.class})
 	@ResponseStatus(HttpStatus.BAD_REQUEST)
 	public ResponseEntity<Object> invalidArguments() {
-		return ResponseEntity.badRequest().build();
-	}
-
-	@ExceptionHandler(InvalidDateException.class)
-	@ResponseStatus(HttpStatus.BAD_REQUEST)
-	public ResponseEntity<Object> invalidDate() {
-		return ResponseEntity.badRequest().build();
-	}
-	@ExceptionHandler(BadBatchReleaseTimeException.class)
-	@ResponseStatus(HttpStatus.BAD_REQUEST)
-	public ResponseEntity<Object> invalidBatchReleaseTime() {
 		return ResponseEntity.badRequest().build();
 	}
 

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/DPPPTController.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/DPPPTController.java
@@ -128,9 +128,6 @@ public class DPPPTController {
 
 		List<Exposee> exposees = new ArrayList<>();
 		for (var exposedKey : exposeeRequests.getExposedKeys()) {
-			if (exposedKey == null) {
-				return ResponseEntity.badRequest().build();
-			}
 			if (!validationUtils.isValidBase64Key(exposedKey.getKey())) {
 				return new ResponseEntity<>("No valid base64 key", HttpStatus.BAD_REQUEST);
 			}

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/DPPPTController.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/DPPPTController.java
@@ -196,9 +196,6 @@ public class DPPPTController {
 	@GetMapping(value = "/buckets/{dayDateStr}", produces = "application/json")
 	public @ResponseBody ResponseEntity<BucketList> getListOfBuckets(@PathVariable String dayDateStr) {
 		OffsetDateTime day = LocalDate.parse(dayDateStr).atStartOfDay().atOffset(ZoneOffset.UTC);
-		if (day.toEpochSecond() < 0) {
-			return ResponseEntity.badRequest().build();
-		}
 		OffsetDateTime currentBucket = day;
 		OffsetDateTime now = OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC);
 		List<Long> bucketList = new ArrayList<>();

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/DebugController.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/DebugController.java
@@ -91,7 +91,7 @@ public class DebugController {
     }
 
     @GetMapping(value = "/exposed/{batchReleaseTime}", produces = "application/zip")
-    public @ResponseBody ResponseEntity<byte[]> getExposedKeys(@PathVariable Long batchReleaseTime, WebRequest request)
+    public @ResponseBody ResponseEntity<byte[]> getExposedKeys(@PathVariable long batchReleaseTime, WebRequest request)
             throws BadBatchReleaseTimeException, IOException, InvalidKeyException,
             NoSuchAlgorithmException, SignatureException {
 

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/GaenController.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/GaenController.java
@@ -18,6 +18,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Date;
@@ -27,6 +28,7 @@ import java.util.concurrent.Callable;
 
 import javax.validation.Valid;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.dpppt.backend.sdk.data.gaen.FakeKeyService;
 import org.dpppt.backend.sdk.data.gaen.GAENDataService;
 import org.dpppt.backend.sdk.model.gaen.DayBuckets;
@@ -50,6 +52,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -316,21 +319,10 @@ public class GaenController {
 		}
 	}
 
-	@ExceptionHandler(IllegalArgumentException.class)
+	@ExceptionHandler({IllegalArgumentException.class, InvalidDateException.class, JsonProcessingException.class,
+			MethodArgumentNotValidException.class, BadBatchReleaseTimeException.class, DateTimeParseException.class})
 	@ResponseStatus(HttpStatus.BAD_REQUEST)
 	public ResponseEntity<Object> invalidArguments() {
-		return ResponseEntity.badRequest().build();
-	}
-
-	@ExceptionHandler(InvalidDateException.class)
-	@ResponseStatus(HttpStatus.BAD_REQUEST)
-	public ResponseEntity<Object> invalidDate() {
-		return ResponseEntity.badRequest().build();
-	}
-
-	@ExceptionHandler(BadBatchReleaseTimeException.class)
-	@ResponseStatus(HttpStatus.BAD_REQUEST)
-	public ResponseEntity<Object> invalidBatchReleaseTime() {
 		return ResponseEntity.badRequest().build();
 	}
 }

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/GaenController.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/GaenController.java
@@ -224,7 +224,7 @@ public class GaenController {
 	}
 
 	@GetMapping(value = "/exposed/{keyDate}", produces = "application/zip")
-	public @ResponseBody ResponseEntity<byte[]> getExposedKeys(@PathVariable Long keyDate,
+	public @ResponseBody ResponseEntity<byte[]> getExposedKeys(@PathVariable long keyDate,
 			@RequestParam(required = false) Long publishedafter, WebRequest request)
 			throws BadBatchReleaseTimeException, IOException, InvalidKeyException, SignatureException,
 			NoSuchAlgorithmException {
@@ -258,7 +258,7 @@ public class GaenController {
 	}
 
 	@GetMapping(value = "/exposedjson/{keyDate}", produces = "application/json")
-	public @ResponseBody ResponseEntity<GaenExposedJson> getExposedKeysAsJson(@PathVariable Long keyDate,
+	public @ResponseBody ResponseEntity<GaenExposedJson> getExposedKeysAsJson(@PathVariable long keyDate,
 			@RequestParam(required = false) Long publishedafter, WebRequest request)
 			throws BadBatchReleaseTimeException {
 		if (!validationUtils.isValidKeyDate(keyDate)) {

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/util/ValidationUtils.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/util/ValidationUtils.java
@@ -59,7 +59,7 @@ public class ValidationUtils {
 	}
 
 	public boolean isValidBatchReleaseTime(Long batchReleaseTime) throws BadBatchReleaseTimeException {
-		if (batchReleaseTime % batchLength != 0) {
+		if (batchReleaseTime == null || batchReleaseTime % batchLength != 0) {
 			throw new BadBatchReleaseTimeException();
 		}
 		if (batchReleaseTime > OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).toInstant().toEpochMilli()) {

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/util/ValidationUtils.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/util/ValidationUtils.java
@@ -55,7 +55,7 @@ public class ValidationUtils {
 	 * @return
 	 */
 	public boolean isValidKeyDate(Long keyDate) {
-		return (Instant.ofEpochMilli(keyDate).atOffset(ZoneOffset.UTC).getHour() == 0);
+		return keyDate != null && (Instant.ofEpochMilli(keyDate).atOffset(ZoneOffset.UTC).getHour() == 0);
 	}
 
 	public boolean isValidBatchReleaseTime(Long batchReleaseTime) throws BadBatchReleaseTimeException {

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/util/ValidationUtils.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/util/ValidationUtils.java
@@ -54,12 +54,12 @@ public class ValidationUtils {
 	 * @param keyDate
 	 * @return
 	 */
-	public boolean isValidKeyDate(Long keyDate) {
-		return keyDate != null && (Instant.ofEpochMilli(keyDate).atOffset(ZoneOffset.UTC).getHour() == 0);
+	public boolean isValidKeyDate(long keyDate) {
+		return (Instant.ofEpochMilli(keyDate).atOffset(ZoneOffset.UTC).getHour() == 0);
 	}
 
-	public boolean isValidBatchReleaseTime(Long batchReleaseTime) throws BadBatchReleaseTimeException {
-		if (batchReleaseTime == null || batchReleaseTime % batchLength != 0) {
+	public boolean isValidBatchReleaseTime(long batchReleaseTime) throws BadBatchReleaseTimeException {
+		if (batchReleaseTime % batchLength != 0) {
 			throw new BadBatchReleaseTimeException();
 		}
 		if (batchReleaseTime > OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).toInstant().toEpochMilli()) {


### PR DESCRIPTION
Hi,

I did a quick scan using the automated testing tool CI Fuzz by Code Intelligence which came up with a few warnings which are fixed in this PR.

The response message for the POST controllers contains the full error message from the json parser including unsanitized HTML characters. This could lead to successful XSS attacks if the API is included for example in a web frontent. Even if this is not the case right now it is easiest to prevent in the backend. With this PR a generic 400 response is returned for these cases.

Multiple unhandled exceptions have also been addressed explicitly.

This PR is an updated version of #90 and includes similar fixes for the /gaen endpoints.