### PR TITLE
Feature/round received at

### DIFF
--- a/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/gaen/JDBCGAENDataServiceImpl.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/gaen/JDBCGAENDataServiceImpl.java
@@ -64,7 +64,7 @@ public class JDBCGAENDataServiceImpl implements GAENDataService {
 			params.addValue("rolling_start_number", gaenKey.getRollingStartNumber());
 			params.addValue("rolling_period", gaenKey.getRollingPeriod());
 			params.addValue("transmission_risk_level", gaenKey.getTransmissionRiskLevel());
-			params.addValue("received_at", Date.from(Instant.ofEpochMilli(receivedAt)));
+			params.addValue("received_at", new Date(receivedAt));
 			
 			parameterList.add(params);
 		}

--- a/dpppt-backend-sdk/dpppt-backend-sdk-data/src/test/java/org/dpppt/backend/sdk/data/config/DPPPTDataServiceConfig.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-data/src/test/java/org/dpppt/backend/sdk/data/config/DPPPTDataServiceConfig.java
@@ -34,6 +34,8 @@ public class DPPPTDataServiceConfig {
 
     @Value("${ws.gaen.randomkeysenabled: true}")
     boolean randomkeysenabled;
+    @Value("${ws.exposedlist.batchlength: 7200000}")
+	long batchLength;
 
     @Autowired
     DataSource dataSource;
@@ -53,7 +55,7 @@ public class DPPPTDataServiceConfig {
 
     @Bean
     public GAENDataService gaenDataService() {
-        return new JDBCGAENDataServiceImpl(dbType, dataSource);
+        return new JDBCGAENDataServiceImpl(dbType, dataSource, Duration.ofMillis(batchLength));
     }
 
     @Bean
@@ -63,7 +65,7 @@ public class DPPPTDataServiceConfig {
 
     @Bean
     public GAENDataService fakeService() {
-        return new JDBCGAENDataServiceImpl("hsql", fakeDataSource());
+        return new JDBCGAENDataServiceImpl("hsql", fakeDataSource(), Duration.ofMillis(batchLength));
     }
 
     @Bean

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/config/WSBaseConfig.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/config/WSBaseConfig.java
@@ -159,7 +159,7 @@ public abstract class WSBaseConfig implements SchedulingConfigurer, WebMvcConfig
 			Flyway flyWay = Flyway.configure().dataSource(fakeDataSource).locations("classpath:/db/migration/hsqldb")
 					.load();
 			flyWay.migrate();
-			GAENDataService fakeGaenService = new JDBCGAENDataServiceImpl("hsql", fakeDataSource);
+			GAENDataService fakeGaenService = new JDBCGAENDataServiceImpl("hsql", fakeDataSource,Duration.ofMillis(batchLength));
 			return new FakeKeyService(fakeGaenService, Integer.valueOf(randomkeyamount),
 					Integer.valueOf(gaenKeySizeBytes), Duration.ofDays(retentionDays), randomkeysenabled);
 		} catch (Exception ex) {
@@ -220,7 +220,7 @@ public abstract class WSBaseConfig implements SchedulingConfigurer, WebMvcConfig
 
 	@Bean
 	public GAENDataService gaenDataService() {
-		return new JDBCGAENDataServiceImpl(getDbType(), dataSource());
+		return new JDBCGAENDataServiceImpl(getDbType(), dataSource(), Duration.ofMillis(batchLength));
 	}
 
 	@Bean

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/controller/GaenControllerTest.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/controller/GaenControllerTest.java
@@ -74,8 +74,7 @@ public class GaenControllerTest extends BaseControllerTest {
 	KeyVault keyVault;
 	@Autowired
 	GAENDataService gaenDataService;
-	@Value("ws.exposedlist.batchlength")
-	Long batchLength;
+	Long batchLength = 7200000L;
 
 	private static final Logger logger = LoggerFactory.getLogger(GaenControllerTest.class);
 
@@ -100,7 +99,7 @@ public class GaenControllerTest extends BaseControllerTest {
 		gaenKey1.setFake(0);
 		gaenKey1.setTransmissionRiskLevel(0);
 		var gaenKey2 = new GaenKey();
-		gaenKey2.setRollingStartNumber((int) Duration.ofMillis(Instant.now().minus(Duration.ofDays(1)).toEpochMilli())
+		gaenKey2.setRollingStartNumber((int) Duration.ofMillis(LocalDate.now(ZoneOffset.UTC).minusDays(1).atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli())
 				.dividedBy(Duration.ofMinutes(10)));
 		gaenKey2.setKeyData(Base64.getEncoder().encodeToString("testKey32Bytes--".getBytes("UTF-8")));
 		gaenKey2.setRollingPeriod(0);
@@ -138,7 +137,7 @@ public class GaenControllerTest extends BaseControllerTest {
 						.content(json(requestList)))
 				.andExpect(status().is(401)).andExpect(request().asyncNotStarted()).andExpect(content().string("")).andReturn();
 
-		var result = gaenDataService.getSortedExposedForKeyDate(LocalDate.now(ZoneOffset.UTC).minusDays(1).atStartOfDay().toInstant(ZoneOffset.UTC).toEpochMilli(),null, (now / batchLength + 1 )*batchLength);
+		var result = gaenDataService.getSortedExposedForKeyDate(LocalDate.now(ZoneOffset.UTC).atStartOfDay().toInstant(ZoneOffset.UTC).toEpochMilli(),null, (now / batchLength + 1 )*batchLength);
 		assertEquals(1, result.size());
 		for(var key : result) {
 			assertEquals(Integer.valueOf(144), key.getRollingPeriod());

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/controller/GaenControllerTest.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/controller/GaenControllerTest.java
@@ -93,15 +93,16 @@ public class GaenControllerTest extends BaseControllerTest {
 		var gaenKey1 = new GaenKey();
 		var now = System.currentTimeMillis();
 		gaenKey1.setRollingStartNumber(
-				(int) Duration.ofMillis(now).dividedBy(Duration.ofMinutes(10)));
-		gaenKey1.setKeyData(Base64.getEncoder().encodeToString("testKey32Bytes--".getBytes("UTF-8")));
+			(int) Duration.ofMillis(LocalDate.now(ZoneOffset.UTC).minusDays(1).atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli())
+			.dividedBy(Duration.ofMinutes(10)));
+		gaenKey1.setKeyData(Base64.getEncoder().encodeToString("testKey32Bytes01".getBytes("UTF-8")));
 		gaenKey1.setRollingPeriod(0);
 		gaenKey1.setFake(0);
 		gaenKey1.setTransmissionRiskLevel(0);
 		var gaenKey2 = new GaenKey();
 		gaenKey2.setRollingStartNumber((int) Duration.ofMillis(LocalDate.now(ZoneOffset.UTC).minusDays(1).atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli())
 				.dividedBy(Duration.ofMinutes(10)));
-		gaenKey2.setKeyData(Base64.getEncoder().encodeToString("testKey32Bytes--".getBytes("UTF-8")));
+		gaenKey2.setKeyData(Base64.getEncoder().encodeToString("testKey32Bytes02".getBytes("UTF-8")));
 		gaenKey2.setRollingPeriod(0);
 		gaenKey2.setFake(0);
 		gaenKey2.setTransmissionRiskLevel(0);
@@ -137,11 +138,14 @@ public class GaenControllerTest extends BaseControllerTest {
 						.content(json(requestList)))
 				.andExpect(status().is(401)).andExpect(request().asyncNotStarted()).andExpect(content().string("")).andReturn();
 
-		var result = gaenDataService.getSortedExposedForKeyDate(LocalDate.now(ZoneOffset.UTC).atStartOfDay().toInstant(ZoneOffset.UTC).toEpochMilli(),null, (now / batchLength + 1 )*batchLength);
-		assertEquals(1, result.size());
+		var result = gaenDataService.getSortedExposedForKeyDate(LocalDate.now(ZoneOffset.UTC).minusDays(1).atStartOfDay().toInstant(ZoneOffset.UTC).toEpochMilli(),null, (now / batchLength + 1 )*batchLength);
+		assertEquals(2, result.size());
 		for(var key : result) {
 			assertEquals(Integer.valueOf(144), key.getRollingPeriod());
 		}
+
+		result = gaenDataService.getSortedExposedForKeyDate(LocalDate.now(ZoneOffset.UTC).minusDays(1).atStartOfDay().toInstant(ZoneOffset.UTC).toEpochMilli(),null, (now / batchLength)*batchLength);
+		assertEquals(0, result.size());
 	}
 
 	@Test

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/controller/GaenControllerTest.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/controller/GaenControllerTest.java
@@ -55,6 +55,7 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -73,6 +74,8 @@ public class GaenControllerTest extends BaseControllerTest {
 	KeyVault keyVault;
 	@Autowired
 	GAENDataService gaenDataService;
+	@Value("ws.exposedlist.batchlength")
+	Long batchLength;
 
 	private static final Logger logger = LoggerFactory.getLogger(GaenControllerTest.class);
 
@@ -89,8 +92,9 @@ public class GaenControllerTest extends BaseControllerTest {
 	public void testMultipleKeyUpload() throws Exception {
 		var requestList = new GaenRequest();
 		var gaenKey1 = new GaenKey();
+		var now = System.currentTimeMillis();
 		gaenKey1.setRollingStartNumber(
-				(int) Duration.ofMillis(Instant.now().toEpochMilli()).dividedBy(Duration.ofMinutes(10)));
+				(int) Duration.ofMillis(now).dividedBy(Duration.ofMinutes(10)));
 		gaenKey1.setKeyData(Base64.getEncoder().encodeToString("testKey32Bytes--".getBytes("UTF-8")));
 		gaenKey1.setRollingPeriod(0);
 		gaenKey1.setFake(0);
@@ -108,7 +112,7 @@ public class GaenControllerTest extends BaseControllerTest {
 		for (int i = 0; i < 12; i++) {
 			var tmpKey = new GaenKey();
 			tmpKey.setRollingStartNumber(
-					(int) Duration.ofMillis(Instant.now().toEpochMilli()).dividedBy(Duration.ofMinutes(10)));
+					(int) Duration.ofMillis(now).dividedBy(Duration.ofMinutes(10)));
 			tmpKey.setKeyData(Base64.getEncoder().encodeToString("testKey32Bytes--".getBytes("UTF-8")));
 			tmpKey.setRollingPeriod(144);
 			tmpKey.setFake(1);
@@ -133,6 +137,12 @@ public class GaenControllerTest extends BaseControllerTest {
 						.header("Authorization", "Bearer " + jwtToken).header("User-Agent", "MockMVC")
 						.content(json(requestList)))
 				.andExpect(status().is(401)).andExpect(request().asyncNotStarted()).andExpect(content().string("")).andReturn();
+
+		var result = gaenDataService.getSortedExposedForKeyDate(LocalDate.now(ZoneOffset.UTC).minusDays(1).atStartOfDay().toInstant(ZoneOffset.UTC).toEpochMilli(),null, (now / batchLength + 1 )*batchLength);
+		assertEquals(1, result.size());
+		for(var key : result) {
+			assertEquals(Integer.valueOf(144), key.getRollingPeriod());
+		}
 	}
 
 	@Test


### PR DESCRIPTION
https://github.com/DP-3T/dp3t-sdk-backend/issues/72

For the GAENDataService received_at is now rounded up such that received_at < bucket+1 is still true.