### PR TITLE
Adding documentation to the DPPPTController API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,9 @@ doc: updatedoc swagger la la2 la3
 
 updateproject:
 	mvn -f dpppt-backend-sdk/pom.xml install
+
 updatedoc:
+	mvn -f dpppt-backend-sdk/pom.xml install -Dmaven.test.skip=true
 	mvn springboot-swagger-3:springboot-swagger-3 -f dpppt-backend-sdk/dpppt-backend-sdk-ws/pom.xml
 	cp dpppt-backend-sdk/dpppt-backend-sdk-ws/generated/swagger/swagger.yaml documentation/yaml/sdk.yaml
 

--- a/documentation/yaml/sdk.yaml
+++ b/documentation/yaml/sdk.yaml
@@ -10,35 +10,43 @@ paths:
   /v1/exposed:
     post:
       summary: addExposee
-      description: addExposee
+      description: Send exposed key to server
       responses:
         '200':
-          description: ''
+          description: The exposed keys have been stored in the database
           content:
             application/json:
               schema:
                 type: string
+        '400':
+          description: Invalid base64 encoding in expose request
+        '403':
+          description: Authentication failed
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/org.dpppt.backend.sdk.model.ExposeeRequest'
-        description: N/A
+        description: The ExposeeRequest contains the SecretKey from the guessed infection
+          date, the infection date itself, and some authentication data to verify
+          the test result
       parameters:
       - name: User-Agent
         in: header
-        description: ''
+        description: App Identifier (PackageName/BundleIdentifier) + App-Version +
+          OS (Android/iOS) + OS-Version
+        example: ch.ubique.android.starsdk;1.0;iOS;13.3
         required: true
         schema:
           type: string
   /v1/:
     get:
       summary: hello
-      description: hello
+      description: Hello return
       responses:
         '200':
-          description: ''
+          description: server live
           content:
             application/json:
               schema:
@@ -46,43 +54,56 @@ paths:
   /v1/exposedlist:
     post:
       summary: addExposee
-      description: addExposee
+      description: Send a list of exposed keys to server
       responses:
         '200':
-          description: ''
+          description: The exposed keys have been stored in the database
           content:
             application/json:
               schema:
                 type: string
+        '400':
+          description: Invalid base64 encoding in exposee request
+        '403':
+          description: Authentication failed
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/org.dpppt.backend.sdk.model.ExposeeRequestList'
-        description: N/A
+        description: The ExposeeRequest contains the SecretKey from the guessed infection
+          date, the infection date itself, and some authentication data to verify
+          the test result
       parameters:
       - name: User-Agent
         in: header
-        description: ''
+        description: App Identifier (PackageName/BundleIdentifier) + App-Version +
+          OS (Android/iOS) + OS-Version
+        example: ch.ubique.android.starsdk;1.0;iOS;13.3
         required: true
         schema:
           type: string
   /v1/exposedjson/{batchReleaseTime}:
     get:
       summary: getExposedByDayDate
-      description: getExposedByDayDate
+      description: Query list of exposed keys from a specific batch release time
       responses:
         '200':
-          description: ''
+          description: Returns ExposedOverview in json format, which includes all
+            exposed keys which were published on _batchReleaseTime_
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/org.dpppt.backend.sdk.model.ExposedOverview'
+        '404':
+          description: Couldn't find _batchReleaseTime_
       parameters:
       - name: batchReleaseTime
         in: path
-        description: ''
+        description: The batch release date of the exposed keys in milliseconds since
+          Unix Epoch (1970-01-01), must be a multiple of 2 * 60 * 60 * 1000
+        example: '1593043200000'
         required: true
         schema:
           type: integer
@@ -90,18 +111,23 @@ paths:
   /v1/exposed/{batchReleaseTime}:
     get:
       summary: getExposedByBatch
-      description: getExposedByBatch
+      description: Query list of exposed keys from a specific batch release time
       responses:
         '200':
-          description: ''
+          description: Returns ExposedOverview in protobuf format, which includes
+            all exposed keys which were published on _batchReleaseTime_
           content:
             application/x-protobuf:
               schema:
                 $ref: '#/components/schemas/org.dpppt.backend.sdk.model.proto.Exposed.ProtoExposedList'
+        '404':
+          description: Couldn't find _batchReleaseTime_
       parameters:
       - name: batchReleaseTime
         in: path
-        description: ''
+        description: The batch release date of the exposed keys in milliseconds since
+          Unix Epoch (1970-01-01), must be a multiple of 2 * 60 * 60 * 1000
+        example: '1593043200000'
         required: true
         schema:
           type: integer
@@ -109,10 +135,12 @@ paths:
   /v1/buckets/{dayDateStr}:
     get:
       summary: getListOfBuckets
-      description: getListOfBuckets
+      description: Query number of available buckets in a given day, starting from
+        midnight UTC
       responses:
         '200':
-          description: ''
+          description: Returns BucketList in json format, indicating all available
+            buckets since _dayDateStr_
           content:
             application/json:
               schema:
@@ -120,7 +148,9 @@ paths:
       parameters:
       - name: dayDateStr
         in: path
-        description: ''
+        description: The date starting when to return the available buckets, in ISO8601
+          date format
+        example: '2019-01-31'
         required: true
         schema:
           type: string
@@ -174,26 +204,7 @@ paths:
         required: true
         schema:
           type: string
-  /v1/gaen/exposedios/{batchReleaseTime}:
-    get:
-      summary: getExposedKeysIos
-      description: getExposedKeysIos
-      responses:
-        '200':
-          description: ''
-          content:
-            application/x-protobuf:
-              schema:
-                $ref: '#/components/schemas/org.dpppt.backend.sdk.model.gaen.proto.FileProto.File'
-      parameters:
-      - name: batchReleaseTime
-        in: path
-        description: ''
-        required: true
-        schema:
-          type: integer
-          format: long
-  /v1/gaen/exposed/{batchReleaseTime}:
+  /v1/gaen/exposed/{keyDate}:
     get:
       summary: getExposedKeys
       description: getExposedKeys
@@ -206,15 +217,64 @@ paths:
                 type: string
                 format: binary
       parameters:
-      - name: batchReleaseTime
+      - name: keyDate
         in: path
         description: ''
         required: true
         schema:
           type: integer
           format: long
-  /v1/gaen/exposedjson/{batchReleaseTime}: {
-    }
+      - name: publishedafter
+        in: query
+        description: ''
+        required: false
+        schema:
+          type: integer
+          format: long
+  /v1/gaen/exposedjson/{keyDate}:
+    get:
+      summary: getExposedKeysAsJson
+      description: getExposedKeysAsJson
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/org.dpppt.backend.sdk.model.gaen.GaenExposedJson'
+      parameters:
+      - name: keyDate
+        in: path
+        description: ''
+        required: true
+        schema:
+          type: integer
+          format: long
+      - name: publishedafter
+        in: query
+        description: ''
+        required: false
+        schema:
+          type: integer
+          format: long
+  /v1/gaen/buckets/{dayDateStr}:
+    get:
+      summary: getBuckets
+      description: getBuckets
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/org.dpppt.backend.sdk.model.gaen.DayBuckets'
+      parameters:
+      - name: dayDateStr
+        in: path
+        description: ''
+        required: true
+        schema:
+          type: string
 components:
   schemas:
     org.dpppt.backend.sdk.model.BucketList:
@@ -287,6 +347,29 @@ components:
             $ref: '#/components/schemas/org.dpppt.backend.sdk.model.ExposedKey'
         fake:
           type: integer
+    org.dpppt.backend.sdk.model.gaen.DayBuckets:
+      type: object
+      properties:
+        dayTimestamp:
+          type: integer
+          format: long
+        day:
+          type: string
+        relativeUrls:
+          type: array
+          items:
+            type: string
+    org.dpppt.backend.sdk.model.gaen.GaenExposedJson:
+      type: object
+      required:
+      - gaenKeys
+      properties:
+        gaenKeys:
+          type: array
+          items:
+            $ref: '#/components/schemas/org.dpppt.backend.sdk.model.gaen.GaenKey'
+        header:
+          $ref: '#/components/schemas/org.dpppt.backend.sdk.model.gaen.Header'
     org.dpppt.backend.sdk.model.gaen.GaenKey:
       type: object
       required:
@@ -324,58 +407,20 @@ components:
       properties:
         delayedKey:
           $ref: '#/components/schemas/org.dpppt.backend.sdk.model.gaen.GaenKey'
-        fake:
-          type: integer
-    org.dpppt.backend.sdk.model.gaen.proto.FileProto.File:
+    org.dpppt.backend.sdk.model.gaen.Header:
       type: object
       properties:
-        bitField0_:
-          type: integer
-        header_:
-          $ref: '#/components/schemas/org.dpppt.backend.sdk.model.gaen.proto.FileProto.Header'
-        key_:
-          type: array
-          items:
-            $ref: '#/components/schemas/org.dpppt.backend.sdk.model.gaen.proto.FileProto.Key'
-        memoizedSize:
-          type: integer
-        memoizedHashCode:
-          type: integer
-    org.dpppt.backend.sdk.model.gaen.proto.FileProto.Header:
-      type: object
-      properties:
-        bitField0_:
-          type: integer
-        startTimestamp_:
+        startTimestamp:
           type: integer
           format: long
-        endTimestamp_:
+        endTimestamp:
           type: integer
           format: long
-        region_:
-          type: object
-        batchNum_:
+        region:
+          type: string
+        batchNum:
           type: integer
-        batchSize_:
-          type: integer
-        memoizedSize:
-          type: integer
-        memoizedHashCode:
-          type: integer
-    org.dpppt.backend.sdk.model.gaen.proto.FileProto.Key:
-      type: object
-      properties:
-        bitField0_:
-          type: integer
-        rollingStartNumber_:
-          type: integer
-        rollingPeriod_:
-          type: integer
-        transmissionRiskLevel_:
-          type: integer
-        memoizedSize:
-          type: integer
-        memoizedHashCode:
+        batchSize:
           type: integer
     org.dpppt.backend.sdk.model.proto.Exposed.ProtoExposedList:
       type: object

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/pom.xml
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/pom.xml
@@ -39,7 +39,7 @@
 		<dependency>
 			<groupId>ch.ubique.openapi</groupId>
 			<artifactId>doc-annotations</artifactId>
-			<version>0.0.5</version>
+			<version>1.0.1</version>
 		</dependency>
 
 		<dependency>
@@ -155,7 +155,7 @@
 			<plugin>
                 <groupId>ch.ubique.openapi</groupId>
                 <artifactId>springboot-swagger-3</artifactId>
-                <version>1.2.4</version>
+                <version>1.2.8</version>
                 <configuration>
                     <apiVersion>1.0-gapple</apiVersion>
                     <basePackages>
@@ -183,20 +183,24 @@
 
 
 	<pluginRepositories>
-    <pluginRepository>
-        <id>github</id>
-          <name>GitHub OWNER Apache Maven Packages</name>
-          <url>https://maven.pkg.github.com/Ubique-OSS/springboot-swagger3</url>
-           <releases><enabled>true</enabled></releases>
-          <snapshots><enabled>true</enabled></snapshots>
-    </pluginRepository>
+		<pluginRepository>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+			<id>ubique-oss-springboot-swagger3</id>
+			<name>bintray</name>
+			<url>https://dl.bintray.com/ubique-oss/springboot-swagger3</url>
+		</pluginRepository>
     </pluginRepositories>
 
     <repositories>
         <repository>
-            <id>github</id>
-            <name>github</name>
-            <url>https://maven.pkg.github.com/Ubique-OSS/springboot-swagger3-annotations</url>
-        </repository>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+			<id>ubique-oss-springboot-swagger3</id>
+			<name>bintray</name>
+			<url>https://dl.bintray.com/ubique-oss/springboot-swagger3</url>
+		</repository>
     </repositories>
 </project>

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/pom.xml
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/pom.xml
@@ -37,6 +37,12 @@
 		</dependency>
 
 		<dependency>
+			<groupId>ch.ubique.openapi</groupId>
+			<artifactId>doc-annotations</artifactId>
+			<version>0.0.5</version>
+		</dependency>
+
+		<dependency>
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
@@ -52,7 +58,7 @@
 			<version>0.11.1</version>
 			<type>pom</type>
 		</dependency>
-	
+
 		<dependency>
 			<groupId>io.jsonwebtoken</groupId>
 			<artifactId>jjwt-jackson</artifactId>
@@ -175,6 +181,7 @@
 		</plugins>
 	</build>
 
+
 	<pluginRepositories>
     <pluginRepository>
         <id>github</id>
@@ -185,4 +192,11 @@
     </pluginRepository>
     </pluginRepositories>
 
+    <repositories>
+        <repository>
+            <id>github</id>
+            <name>github</name>
+            <url>https://maven.pkg.github.com/Ubique-OSS/springboot-swagger3-annotations</url>
+        </repository>
+    </repositories>
 </project>

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/DPPPTController.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/DPPPTController.java
@@ -51,6 +51,8 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.context.request.WebRequest;
 
+import ch.ubique.openapi.docannotations.Documentation;
+
 import com.google.protobuf.ByteString;
 
 @Controller
@@ -80,14 +82,26 @@ public class DPPPTController {
 
 	@CrossOrigin(origins = { "https://editor.swagger.io" })
 	@GetMapping(value = "")
+	@Documentation(description = "Hello return", responses = {"200=>server live"})
 	public @ResponseBody ResponseEntity<String> hello() {
 		return ResponseEntity.ok().header("X-HELLO", "dp3t").body("Hello from DP3T WS");
 	}
 
 	@CrossOrigin(origins = { "https://editor.swagger.io" })
 	@PostMapping(value = "/exposed")
-	public @ResponseBody ResponseEntity<String> addExposee(@Valid @RequestBody ExposeeRequest exposeeRequest,
-			@RequestHeader(value = "User-Agent", required = true) String userAgent,
+	@Documentation(
+			description = "Send exposed key to server",
+			responses = {
+					"200=>The exposed keys have been stored in the database",
+					"400=>Invalid base64 encoding in expose request",
+					"403=>Authentication failed"
+			})
+	public @ResponseBody ResponseEntity<String> addExposee(@Valid @RequestBody
+															   @Documentation(description = "The ExposeeRequest contains the SecretKey from the guessed infection date, the infection date itself, and some authentication data to verify the test result")
+																	   ExposeeRequest exposeeRequest,
+			@RequestHeader(value = "User-Agent", required = true)
+            @Documentation(description = "App Identifier (PackageName/BundleIdentifier) + App-Version + OS (Android/iOS) + OS-Version", example = "ch.ubique.android.starsdk;1.0;iOS;13.3")
+                    String userAgent,
 			@AuthenticationPrincipal Object principal) throws InvalidDateException {
 		long now = System.currentTimeMillis();
 		if (!this.validateRequest.isValid(principal)) {
@@ -118,8 +132,17 @@ public class DPPPTController {
 
 	@CrossOrigin(origins = { "https://editor.swagger.io" })
 	@PostMapping(value = "/exposedlist")
-	public @ResponseBody ResponseEntity<String> addExposee(@Valid @RequestBody ExposeeRequestList exposeeRequests,
-			@RequestHeader(value = "User-Agent", required = true) String userAgent,
+	@Documentation(description = "Send a list of exposed keys to server",
+			responses = {
+	                "200=>The exposed keys have been stored in the database",
+			        "400=>Invalid base64 encoding in exposee request",
+                    "403=>Authentication failed"})
+	public @ResponseBody ResponseEntity<String> addExposee(@Valid @RequestBody
+                                                               @Documentation(description = "The ExposeeRequest contains the SecretKey from the guessed infection date, the infection date itself, and some authentication data to verify the test result")
+                                                                       ExposeeRequestList exposeeRequests,
+			@RequestHeader(value = "User-Agent", required = true)
+            @Documentation(description = "App Identifier (PackageName/BundleIdentifier) + App-Version + OS (Android/iOS) + OS-Version", example = "ch.ubique.android.starsdk;1.0;iOS;13.3")
+                    String userAgent,
 			@AuthenticationPrincipal Object principal) throws InvalidDateException {
 		long now = System.currentTimeMillis();
 		if (!this.validateRequest.isValid(principal)) {
@@ -156,7 +179,15 @@ public class DPPPTController {
 
 	@CrossOrigin(origins = { "https://editor.swagger.io" })
 	@GetMapping(value = "/exposedjson/{batchReleaseTime}", produces = "application/json")
-	public @ResponseBody ResponseEntity<ExposedOverview> getExposedByDayDate(@PathVariable long batchReleaseTime,
+	@Documentation(description = "Query list of exposed keys from a specific batch release time",
+			responses = {
+	                "200=>Returns ExposedOverview in json format, which includes all exposed keys which were published on _batchReleaseTime_",
+                    "404=>Couldn't find _batchReleaseTime_"
+	})
+	public @ResponseBody ResponseEntity<ExposedOverview> getExposedByDayDate(@PathVariable
+                                                                                 @Documentation(description = "The batch release date of the exposed keys in milliseconds since Unix Epoch (1970-01-01), must be a multiple of 2 * 60 * 60 * 1000",
+                                                                                         example = "1593043200000")
+                                                                                         long batchReleaseTime,
 			WebRequest request) throws BadBatchReleaseTimeException{
 		if(!validationUtils.isValidBatchReleaseTime(batchReleaseTime)) {
 			return ResponseEntity.notFound().build();
@@ -171,7 +202,15 @@ public class DPPPTController {
 
 	@CrossOrigin(origins = { "https://editor.swagger.io" })
 	@GetMapping(value = "/exposed/{batchReleaseTime}", produces = "application/x-protobuf")
-	public @ResponseBody ResponseEntity<Exposed.ProtoExposedList> getExposedByBatch(@PathVariable long batchReleaseTime,
+    @Documentation(description = "Query list of exposed keys from a specific batch release time",
+            responses = {
+                    "200=>Returns ExposedOverview in protobuf format, which includes all exposed keys which were published on _batchReleaseTime_",
+                    "404=>Couldn't find _batchReleaseTime_"
+            })
+	public @ResponseBody ResponseEntity<Exposed.ProtoExposedList> getExposedByBatch(@PathVariable
+                                                                                        @Documentation(description = "The batch release date of the exposed keys in milliseconds since Unix Epoch (1970-01-01), must be a multiple of 2 * 60 * 60 * 1000",
+                                                                                                example = "1593043200000")
+                                                                                                long batchReleaseTime,
 			WebRequest request) throws BadBatchReleaseTimeException {
 		if(!validationUtils.isValidBatchReleaseTime(batchReleaseTime)) {
 			return ResponseEntity.notFound().build();
@@ -194,7 +233,13 @@ public class DPPPTController {
 
 	@CrossOrigin(origins = { "https://editor.swagger.io" })
 	@GetMapping(value = "/buckets/{dayDateStr}", produces = "application/json")
-	public @ResponseBody ResponseEntity<BucketList> getListOfBuckets(@PathVariable String dayDateStr) {
+    @Documentation(description = "Query number of available buckets in a given day, starting from midnight UTC",
+            responses = {
+                    "200=>Returns BucketList in json format, indicating all available buckets since _dayDateStr_"
+            })
+	public @ResponseBody ResponseEntity<BucketList> getListOfBuckets(@PathVariable
+                                                                         @Documentation(description = "The date starting when to return the available buckets, in ISO8601 date format", example = "2019-01-31")
+                                                                                 String dayDateStr) {
 		OffsetDateTime day = LocalDate.parse(dayDateStr).atStartOfDay().atOffset(ZoneOffset.UTC);
 		OffsetDateTime currentBucket = day;
 		OffsetDateTime now = OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC);


### PR DESCRIPTION
This PR re-adds the API Documentation similar to how it was before the commit 04bd32afe8df55ae0e21d3f804ce6f04c29507ce

More specifically, this does:
1. add a dependency to `ch.ubique.openapi.docannotations`
2. add `@Documentation` annotations to `DPPPTController.java`
3. modivy the `updatedoc` target in the `Makefile` to correctly re-create the documentation only

Before this PR is merged, the following needs to happen:
 - [x] BIT agrees on including this new dependency
 - [x] `ch.ubique.openapi.docannotations` is included in the official, standard maven repository