### PR TITLE
rename bucketLength and batchLength to releaseBucketDuration

### DIFF
--- a/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/DPPPTDataService.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/DPPPTDataService.java
@@ -37,19 +37,19 @@ public interface DPPPTDataService {
 	 * Returns the maximum id of the stored exposed entries fo the given batch.
 	 * 
 	 * @param batchReleaseTime in milliseconds since the start of the Unix Epoch, must be a multiple of
-	 * @param batchLength in milliseconds
+	 * @param releaseBucketDuration in milliseconds
 	 * @return the maximum id of the stored exposed entries fo the given batch
 	 */
-	int getMaxExposedIdForBatchReleaseTime(long batchReleaseTime, long batchLength);
+	int getMaxExposedIdForBatchReleaseTime(long batchReleaseTime, long releaseBucketDuration);
 
 	/**
 	 * Returns all exposees for the given batch.
 	 *
 	 * @param batchReleaseTime in milliseconds since the start of the Unix Epoch, must be a multiple of
-	 * @param batchLength in milliseconds
+	 * @param releaseBucketDuration in milliseconds
 	 * @return all exposees for the given batch
 	 */
-	List<Exposee> getSortedExposedForBatchReleaseTime(long batchReleaseTime, long batchLength);
+	List<Exposee> getSortedExposedForBatchReleaseTime(long batchReleaseTime, long releaseBucketDuration);
 
 	/**
 	 * deletes entries older than retentionperiod

--- a/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/JDBCDPPPTDataServiceImpl.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/JDBCDPPPTDataServiceImpl.java
@@ -82,10 +82,10 @@ public class JDBCDPPPTDataServiceImpl implements DPPPTDataService {
 
 	@Override
 	@Transactional(readOnly = true)
-	public int getMaxExposedIdForBatchReleaseTime(long batchReleaseTime, long batchLength) {
+	public int getMaxExposedIdForBatchReleaseTime(long batchReleaseTime, long releaseBucketDuration) {
 		MapSqlParameterSource params = new MapSqlParameterSource();
 		params.addValue("batchReleaseTime", Date.from(Instant.ofEpochMilli(batchReleaseTime)));
-		params.addValue("startBatch", Date.from(Instant.ofEpochMilli(batchReleaseTime - batchLength)));
+		params.addValue("startBatch", Date.from(Instant.ofEpochMilli(batchReleaseTime - releaseBucketDuration)));
 		String sql = "select max(pk_exposed_id) from t_exposed where received_at >= :startBatch and received_at < :batchReleaseTime";
 		Integer maxId = jt.queryForObject(sql, params, Integer.class);
 		if (maxId == null) {
@@ -97,11 +97,11 @@ public class JDBCDPPPTDataServiceImpl implements DPPPTDataService {
 
 	@Override
 	@Transactional(readOnly = true)
-	public List<Exposee> getSortedExposedForBatchReleaseTime(long batchReleaseTime, long batchLength) {
+	public List<Exposee> getSortedExposedForBatchReleaseTime(long batchReleaseTime, long releaseBucketDuration) {
 		String sql = "select pk_exposed_id, key, key_date from t_exposed where received_at >= :startBatch and received_at < :batchReleaseTime order by pk_exposed_id desc";
 		MapSqlParameterSource params = new MapSqlParameterSource();
 		params.addValue("batchReleaseTime", Date.from(Instant.ofEpochMilli(batchReleaseTime)));
-		params.addValue("startBatch", Date.from(Instant.ofEpochMilli(batchReleaseTime - batchLength)));
+		params.addValue("startBatch", Date.from(Instant.ofEpochMilli(batchReleaseTime - releaseBucketDuration)));
 		return jt.query(sql, params, new ExposeeRowMapper());
 	}
 

--- a/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/gaen/DebugGAENDataService.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/gaen/DebugGAENDataService.java
@@ -29,9 +29,9 @@ public interface DebugGAENDataService {
 	 * Returns all exposed keys for the given batch from the debug store.
 	 * 
 	 * @param batchReleaseTime in milliseconds since the beginning of the Unix epoch (1970-01-01)
-	 * @param batchLength in milliseconds
+	 * @param releaseBucketDuration in milliseconds
 	 * @return all exposed keys for the given batch from the debug store
 	 */
-	Map<String, List<GaenKey>> getSortedExposedForBatchReleaseTime(Long batchReleaseTime, long batchLength);
+	Map<String, List<GaenKey>> getSortedExposedForBatchReleaseTime(Long batchReleaseTime, long releaseBucketDuration);
 
 }

--- a/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/gaen/DebugJDBCGAENDataServiceImpl.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/gaen/DebugJDBCGAENDataServiceImpl.java
@@ -65,11 +65,11 @@ public class DebugJDBCGAENDataServiceImpl implements DebugGAENDataService {
 
 	@Override
 	@Transactional(readOnly = true)
-	public Map<String, List<GaenKey>> getSortedExposedForBatchReleaseTime(Long batchReleaseTime, long batchLength) {
+	public Map<String, List<GaenKey>> getSortedExposedForBatchReleaseTime(Long batchReleaseTime, long releaseBucketDuration) {
 		String sql = "select pk_exposed_id, device_name, key, rolling_start_number, rolling_period, transmission_risk_level from t_debug_gaen_exposed where received_at >= :startBatch and received_at < :batchReleaseTime order by pk_exposed_id desc";
 		MapSqlParameterSource params = new MapSqlParameterSource();
 		params.addValue("batchReleaseTime", Date.from(Instant.ofEpochMilli(batchReleaseTime)));
-		params.addValue("startBatch", Date.from(Instant.ofEpochMilli(batchReleaseTime - batchLength)));
+		params.addValue("startBatch", Date.from(Instant.ofEpochMilli(batchReleaseTime - releaseBucketDuration)));
 		return jt.query(sql, params, new DebugGaenKeyResultSetExtractor());
 	}
 

--- a/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/gaen/JDBCGAENDataServiceImpl.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/gaen/JDBCGAENDataServiceImpl.java
@@ -35,12 +35,12 @@ public class JDBCGAENDataServiceImpl implements GAENDataService {
 	private static final String PGSQL = "pgsql";
 	private final String dbType;
 	private final NamedParameterJdbcTemplate jt;
-	private final Duration bucketLength;
+	private final Duration releaseBucketDuration;
 
-	public JDBCGAENDataServiceImpl(String dbType, DataSource dataSource, Duration bucketLength) {
+	public JDBCGAENDataServiceImpl(String dbType, DataSource dataSource, Duration releaseBucketDuration) {
 		this.dbType = dbType;
 		this.jt = new NamedParameterJdbcTemplate(dataSource);
-		this.bucketLength = bucketLength;
+		this.releaseBucketDuration = releaseBucketDuration;
 	}
 
 	@Override
@@ -57,7 +57,7 @@ public class JDBCGAENDataServiceImpl implements GAENDataService {
 		}
 		var parameterList = new ArrayList<MapSqlParameterSource>();
 		var nowMillis = System.currentTimeMillis();
-		var receivedAt = (nowMillis/bucketLength.toMillis() + 1) * bucketLength.toMillis() - 1;
+		var receivedAt = (nowMillis/releaseBucketDuration.toMillis() + 1) * releaseBucketDuration.toMillis() - 1;
 		for (var gaenKey : gaenKeys) {
 			MapSqlParameterSource params = new MapSqlParameterSource();
 			params.addValue("key", gaenKey.getKeyData());

--- a/dpppt-backend-sdk/dpppt-backend-sdk-data/src/test/java/org/dpppt/backend/sdk/data/config/DPPPTDataServiceConfig.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-data/src/test/java/org/dpppt/backend/sdk/data/config/DPPPTDataServiceConfig.java
@@ -34,8 +34,8 @@ public class DPPPTDataServiceConfig {
 
     @Value("${ws.gaen.randomkeysenabled: true}")
     boolean randomkeysenabled;
-    @Value("${ws.exposedlist.batchlength: 7200000}")
-	long batchLength;
+    @Value("${ws.exposedlist.releaseBucketDuration: 7200000}")
+	long releaseBucketDuration;
 
     @Autowired
     DataSource dataSource;
@@ -55,7 +55,7 @@ public class DPPPTDataServiceConfig {
 
     @Bean
     public GAENDataService gaenDataService() {
-        return new JDBCGAENDataServiceImpl(dbType, dataSource, Duration.ofMillis(batchLength));
+        return new JDBCGAENDataServiceImpl(dbType, dataSource, Duration.ofMillis(releaseBucketDuration));
     }
 
     @Bean
@@ -65,7 +65,7 @@ public class DPPPTDataServiceConfig {
 
     @Bean
     public GAENDataService fakeService() {
-        return new JDBCGAENDataServiceImpl("hsql", fakeDataSource(), Duration.ofMillis(batchLength));
+        return new JDBCGAENDataServiceImpl("hsql", fakeDataSource(), Duration.ofMillis(releaseBucketDuration));
     }
 
     @Bean

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/config/WSBaseConfig.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/config/WSBaseConfig.java
@@ -101,8 +101,8 @@ public abstract class WSBaseConfig implements SchedulingConfigurer, WebMvcConfig
 	@Value("${ws.retentiondays: 14}")
 	int retentionDays;
 
-	@Value("${ws.exposedlist.batchlength: 7200000}")
-	long batchLength;
+	@Value("${ws.exposedlist.releaseBucketDuration: 7200000}")
+	long releaseBucketDuration;
 
 	@Value("${ws.exposedlist.requestTime: 1500}")
 	long requestTime;
@@ -165,7 +165,7 @@ public abstract class WSBaseConfig implements SchedulingConfigurer, WebMvcConfig
 			Flyway flyWay = Flyway.configure().dataSource(fakeDataSource).locations("classpath:/db/migration/hsqldb")
 					.load();
 			flyWay.migrate();
-			GAENDataService fakeGaenService = new JDBCGAENDataServiceImpl("hsql", fakeDataSource,Duration.ofMillis(batchLength));
+			GAENDataService fakeGaenService = new JDBCGAENDataServiceImpl("hsql", fakeDataSource,Duration.ofMillis(releaseBucketDuration));
 			return new FakeKeyService(fakeGaenService, Integer.valueOf(randomkeyamount),
 					Integer.valueOf(gaenKeySizeBytes), Duration.ofDays(retentionDays), randomkeysenabled);
 		} catch (Exception ex) {
@@ -177,7 +177,7 @@ public abstract class WSBaseConfig implements SchedulingConfigurer, WebMvcConfig
 	public ProtoSignature gaenSigner() {
 		try {
 			return new ProtoSignature(gaenAlgorithm, keyVault.get("gaen"), getBundleId(), getPackageName(),
-					getKeyVersion(), getKeyIdentifier(), gaenRegion, Duration.ofMillis(batchLength));
+					getKeyVersion(), getKeyIdentifier(), gaenRegion, Duration.ofMillis(releaseBucketDuration));
 		} catch (Exception ex) {
 			throw new RuntimeException("Cannot initialize signer for protobuf");
 		}
@@ -190,17 +190,17 @@ public abstract class WSBaseConfig implements SchedulingConfigurer, WebMvcConfig
 			theValidator = new NoValidateRequest();
 		}
 		return new DPPPTController(dppptSDKDataService(), appSource, exposedListCacheControl, theValidator,
-				dpptValidationUtils(), batchLength, requestTime);
+				dpptValidationUtils(), releaseBucketDuration, requestTime);
 	}
 
 	@Bean
 	public ValidationUtils dpptValidationUtils() {
-		return new ValidationUtils(keySizeBytes, Duration.ofDays(retentionDays), batchLength);
+		return new ValidationUtils(keySizeBytes, Duration.ofDays(retentionDays), releaseBucketDuration);
 	}
 
 	@Bean
 	public ValidationUtils gaenValidationUtils() {
-		return new ValidationUtils(gaenKeySizeBytes, Duration.ofDays(retentionDays), batchLength);
+		return new ValidationUtils(gaenKeySizeBytes, Duration.ofDays(retentionDays), releaseBucketDuration);
 	}
 
 	@Bean
@@ -210,7 +210,7 @@ public abstract class WSBaseConfig implements SchedulingConfigurer, WebMvcConfig
 			theValidator = backupValidator();
 		}
 		return new GaenController(gaenDataService(), fakeKeyService(), theValidator, gaenSigner(),
-				gaenValidationUtils(), Duration.ofMillis(batchLength), Duration.ofMillis(requestTime),
+				gaenValidationUtils(), Duration.ofMillis(releaseBucketDuration), Duration.ofMillis(requestTime),
 				Duration.ofMillis(exposedListCacheControl), keyVault.get("nextDayJWT").getPrivate());
 	}
 
@@ -226,7 +226,7 @@ public abstract class WSBaseConfig implements SchedulingConfigurer, WebMvcConfig
 
 	@Bean
 	public GAENDataService gaenDataService() {
-		return new JDBCGAENDataServiceImpl(getDbType(), dataSource(), Duration.ofMillis(batchLength));
+		return new JDBCGAENDataServiceImpl(getDbType(), dataSource(), Duration.ofMillis(releaseBucketDuration));
 	}
 
 	@Bean

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/config/WSProdConfig.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/config/WSProdConfig.java
@@ -138,8 +138,8 @@ public class WSProdConfig extends WSBaseConfig {
 	@Profile("debug")
 	@Configuration
 	public static class DebugConfig {
-		@Value("${ws.exposedlist.debug.batchlength: 86400000}")
-		long batchLength;
+		@Value("${ws.exposedlist.debug.releaseBucketDuration: 86400000}")
+		long releaseBucketDuration;
 	
 		@Value("${ws.exposedlist.debug.requestTime: 1500}")
 		long requestTime;
@@ -178,7 +178,7 @@ public class WSProdConfig extends WSBaseConfig {
 		}
 		@Bean
 		DebugController debugController() {
-			return new DebugController(dataService(),gaenSigner,backupValidator, gaenValidationUtils,Duration.ofMillis(batchLength), Duration.ofMillis(requestTime));
+			return new DebugController(dataService(),gaenSigner,backupValidator, gaenValidationUtils,Duration.ofMillis(releaseBucketDuration), Duration.ofMillis(requestTime));
 		}
 	}
 

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/DPPPTController.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/DPPPTController.java
@@ -65,19 +65,19 @@ public class DPPPTController {
 	private final ValidateRequest validateRequest;
 	private final ValidationUtils validationUtils;
 	// time in milliseconds that exposed keys are hidden before being served, in order to prevent timing attacks
-	private final long batchLength;
+	private final long releaseBucketDuration;
 	private final long requestTime;
 
 
 	public DPPPTController(DPPPTDataService dataService, String appSource,
-			int exposedListCacheControl, ValidateRequest validateRequest, ValidationUtils validationUtils, long batchLength,
+			int exposedListCacheControl, ValidateRequest validateRequest, ValidationUtils validationUtils, long releaseBucketDuration,
 			long requestTime) {
 		this.dataService = dataService;
 		this.appSource = appSource;
 		this.exposedListCacheControl = exposedListCacheControl/1000/60;
 		this.validateRequest = validateRequest;
 		this.validationUtils = validationUtils;
-		this.batchLength = batchLength;
+		this.releaseBucketDuration = releaseBucketDuration;
 		this.requestTime = requestTime;
 	}
 
@@ -194,7 +194,7 @@ public class DPPPTController {
 			return ResponseEntity.notFound().build();
 		}
 
-		List<Exposee> exposeeList = dataService.getSortedExposedForBatchReleaseTime(batchReleaseTime, batchLength);
+		List<Exposee> exposeeList = dataService.getSortedExposedForBatchReleaseTime(batchReleaseTime, releaseBucketDuration);
 		ExposedOverview overview = new ExposedOverview(exposeeList);
 		overview.setBatchReleaseTime(batchReleaseTime);
 		return ResponseEntity.ok().cacheControl(CacheControl.maxAge(Duration.ofMinutes(exposedListCacheControl)))
@@ -217,7 +217,7 @@ public class DPPPTController {
 			return ResponseEntity.notFound().build();
 		}
 
-		List<Exposee> exposeeList = dataService.getSortedExposedForBatchReleaseTime(batchReleaseTime, batchLength);
+		List<Exposee> exposeeList = dataService.getSortedExposedForBatchReleaseTime(batchReleaseTime, releaseBucketDuration);
 		List<Exposed.ProtoExposee> exposees = new ArrayList<>();
 		for (Exposee exposee : exposeeList) {
 			Exposed.ProtoExposee protoExposee = Exposed.ProtoExposee.newBuilder()
@@ -248,7 +248,7 @@ public class DPPPTController {
 		while (currentBucket.toInstant().toEpochMilli() < Math.min(day.plusDays(1).toInstant().toEpochMilli(),
 				now.toInstant().toEpochMilli())) {
 			bucketList.add(currentBucket.toInstant().toEpochMilli());
-			currentBucket = currentBucket.plusSeconds(batchLength / 1000);
+			currentBucket = currentBucket.plusSeconds(releaseBucketDuration / 1000);
 		}
 		BucketList list = new BucketList();
 		list.setBuckets(bucketList);

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/DebugController.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/DebugController.java
@@ -41,15 +41,15 @@ import org.springframework.web.context.request.WebRequest;
 public class DebugController {
     private final ValidateRequest validateRequest;
     private final ValidationUtils validationUtils;
-    private final Duration bucketLength;
+    private final Duration releaseBucketDuration;
     private final Duration requestTime;
     private final ProtoSignature gaenSigner;
     private final DebugGAENDataService dataService;
 
-    public DebugController(DebugGAENDataService dataService, ProtoSignature gaenSigner, ValidateRequest validateRequest, ValidationUtils validationUtils, Duration bucketLength, Duration requestTime) {
+    public DebugController(DebugGAENDataService dataService, ProtoSignature gaenSigner, ValidateRequest validateRequest, ValidationUtils validationUtils, Duration releaseBucketDuration, Duration requestTime) {
         this.validateRequest = validateRequest;
         this.validationUtils = validationUtils;
-        this.bucketLength = bucketLength;
+        this.releaseBucketDuration = releaseBucketDuration;
         this.requestTime = requestTime;
         this.gaenSigner = gaenSigner;
         this.dataService = dataService;
@@ -96,11 +96,11 @@ public class DebugController {
             NoSuchAlgorithmException, SignatureException {
 
         var batchReleaseTimeDuration = Duration.ofMillis(batchReleaseTime);
-        if (batchReleaseTime % bucketLength.toMillis() != 0) {
+        if (batchReleaseTime % releaseBucketDuration.toMillis() != 0) {
             return ResponseEntity.notFound().build();
         }
 
-        var exposedKeys = dataService.getSortedExposedForBatchReleaseTime(batchReleaseTimeDuration.toMillis(), bucketLength.toMillis());
+        var exposedKeys = dataService.getSortedExposedForBatchReleaseTime(batchReleaseTimeDuration.toMillis(), releaseBucketDuration.toMillis());
         
         byte[] payload = gaenSigner.getPayload(exposedKeys);
         
@@ -126,7 +126,7 @@ public class DebugController {
         while (atStartOfDay.toInstant().toEpochMilli() < Math.min(now.toInstant().toEpochMilli(),
                 end.toInstant().toEpochMilli())) {
             relativeUrls.add(controllerMapping + "/exposed" + "/" + atStartOfDay.toInstant().toEpochMilli());
-            atStartOfDay = atStartOfDay.plus(this.bucketLength);
+            atStartOfDay = atStartOfDay.plus(this.releaseBucketDuration);
         }
 
         return ResponseEntity.ok(dayBuckets);

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/security/signature/ProtoSignature.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/security/signature/ProtoSignature.java
@@ -50,12 +50,12 @@ public class ProtoSignature {
 	private final String keyVersion;
 	private final String keyVerificationId;
 	private final String gaenRegion;
-	private final Duration bucketLength;
+	private final Duration releaseBucketDuration;
 
 	public Map<String, String> oidToJavaSignature = Map.of("1.2.840.10045.4.3.2", "SHA256withECDSA");
 
 	public ProtoSignature(String algorithm, KeyPair keyPair, String appBundleId, String apkPackage, String keyVersion,
-			String keyVerificationId, String gaenRegion, Duration bucketLength) {
+			String keyVerificationId, String gaenRegion, Duration releaseBucketDuration) {
 		this.keyPair = keyPair;
 		this.algorithm = algorithm.trim();
 		this.appBundleId = appBundleId;
@@ -63,7 +63,7 @@ public class ProtoSignature {
 		this.keyVerificationId = keyVerificationId;
 		this.keyVersion = keyVersion;
 		this.gaenRegion = gaenRegion;
-		this.bucketLength = bucketLength;
+		this.releaseBucketDuration = releaseBucketDuration;
 	}
 
 	/**
@@ -223,7 +223,7 @@ public class ProtoSignature {
 
 		file.setRegion(gaenRegion).setBatchNum(1).setBatchSize(1)
 				.setStartTimestamp(batchReleaseTimeDuration.toSeconds())
-				.setEndTimestamp(batchReleaseTimeDuration.toSeconds() + bucketLength.toSeconds());
+				.setEndTimestamp(batchReleaseTimeDuration.toSeconds() + releaseBucketDuration.toSeconds());
 
 		file.addSignatureInfos(tekSignature());
 

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/util/ValidationUtils.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/util/ValidationUtils.java
@@ -23,19 +23,19 @@ import java.util.Base64;
 public class ValidationUtils {
 	private final int KEY_LENGTH_BYTES;
 	private final Duration retentionPeriod;
-	private final Long batchLength;
+	private final Long releaseBucketDuration;
 
 	/**
 	 * Initialize the validator with the current parameters in use.
 	 *
 	 * @param keyLengthBytes how long the exposed keys are, in bytes
 	 * @param retentionPeriod period during which the exposed keys are stored, before they are deleted
-	 * @param batchLength time in milliseconds that exposed keys are hidden before being served, in order to prevent timing attacks
+	 * @param releaseBucketDuration time in milliseconds that exposed keys are hidden before being served, in order to prevent timing attacks
 	 */
-	public ValidationUtils(int keyLengthBytes, Duration retentionPeriod, Long batchLength) {
+	public ValidationUtils(int keyLengthBytes, Duration retentionPeriod, Long releaseBucketDuration) {
 		this.KEY_LENGTH_BYTES = keyLengthBytes;
 		this.retentionPeriod = retentionPeriod;
-		this.batchLength = batchLength;
+		this.releaseBucketDuration = releaseBucketDuration;
 	}
 
 	/**
@@ -89,7 +89,7 @@ public class ValidationUtils {
 	 * @throws BadBatchReleaseTimeException if batchReleaseTime is not on a batch boundary
 	 */
 	public boolean isValidBatchReleaseTime(long batchReleaseTime) throws BadBatchReleaseTimeException {
-		if (batchReleaseTime % batchLength != 0) {
+		if (batchReleaseTime % releaseBucketDuration != 0) {
 			throw new BadBatchReleaseTimeException();
 		}
 		return this.isDateInRange(OffsetDateTime.ofInstant(Instant.ofEpochMilli(batchReleaseTime), ZoneOffset.UTC));

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/controller/DPPPTControllerNoSecurityTest.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/controller/DPPPTControllerNoSecurityTest.java
@@ -139,15 +139,15 @@ public class DPPPTControllerNoSecurityTest extends BaseControllerNoSecurityTest 
 		Iterator<JsonNode> buckets = mapper.readTree(response.getContentAsString()).get("buckets").elements();
 		Long first = buckets.next().asLong();
 		Long next = buckets.next().asLong();
-		Long batchLength = next - first;
+		Long releaseBucketDuration = next - first;
 		long future = (long) Math
 				.floor(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).plusDays(1).toInstant().toEpochMilli()
-						/ batchLength)
-				* batchLength;
+						/ releaseBucketDuration)
+				* releaseBucketDuration;
 		long past = (long) Math.floor(
 				OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).minusYears(1).toInstant().toEpochMilli()
-						/ batchLength)
-				* batchLength;
+						/ releaseBucketDuration)
+				* releaseBucketDuration;
 
 		response = mockMvc.perform(get("/v1/exposed/" + Long.toString(future))).andExpect(status().isNotFound())
 				.andReturn().getResponse();

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/controller/GaenControllerNoFilledZipsTest.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/controller/GaenControllerNoFilledZipsTest.java
@@ -16,7 +16,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest(properties = {
         "ws.app.jwt.publickey=classpath://generated_pub.pem",
-        "logging.level.org.springframework.security=DEBUG", "ws.exposedlist.batchlength=7200000",
+        "logging.level.org.springframework.security=DEBUG", "ws.exposedlist.releaseBucketDuration=7200000",
         "ws.gaen.randomkeysenabled=false" })
 public class GaenControllerNoFilledZipsTest extends BaseControllerTest {
     @Test

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/controller/GaenControllerTest.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/controller/GaenControllerTest.java
@@ -68,7 +68,7 @@ import io.jsonwebtoken.Jwts;
 
 @ActiveProfiles({"actuator-security"})
 @SpringBootTest(properties = { "ws.app.jwt.publickey=classpath://generated_pub.pem",
-		"logging.level.org.springframework.security=DEBUG", "ws.exposedlist.batchlength=7200000", "ws.gaen.randomkeysenabled=true",
+		"logging.level.org.springframework.security=DEBUG", "ws.exposedlist.releaseBucketDuration=7200000", "ws.gaen.randomkeysenabled=true",
 	"ws.monitor.prometheus.user=prometheus",
 	"ws.monitor.prometheus.password=prometheus",
 	"management.endpoints.enabled-by-default=true",
@@ -80,7 +80,7 @@ public class GaenControllerTest extends BaseControllerTest {
 	KeyVault keyVault;
 	@Autowired
 	GAENDataService gaenDataService;
-	Long batchLength = 7200000L;
+	Long releaseBucketDuration = 7200000L;
 
 	private static final Logger logger = LoggerFactory.getLogger(GaenControllerTest.class);
 
@@ -157,13 +157,13 @@ public class GaenControllerTest extends BaseControllerTest {
 						.content(json(requestList)))
 				.andExpect(status().is(401)).andExpect(request().asyncNotStarted()).andExpect(content().string("")).andReturn();
 
-		var result = gaenDataService.getSortedExposedForKeyDate(LocalDate.now(ZoneOffset.UTC).minusDays(1).atStartOfDay().toInstant(ZoneOffset.UTC).toEpochMilli(),null, (now / batchLength + 1 )*batchLength);
+		var result = gaenDataService.getSortedExposedForKeyDate(LocalDate.now(ZoneOffset.UTC).minusDays(1).atStartOfDay().toInstant(ZoneOffset.UTC).toEpochMilli(),null, (now / releaseBucketDuration + 1 )*releaseBucketDuration);
 		assertEquals(2, result.size());
 		for(var key : result) {
 			assertEquals(Integer.valueOf(144), key.getRollingPeriod());
 		}
 
-		result = gaenDataService.getSortedExposedForKeyDate(LocalDate.now(ZoneOffset.UTC).minusDays(1).atStartOfDay().toInstant(ZoneOffset.UTC).toEpochMilli(),null, (now / batchLength)*batchLength);
+		result = gaenDataService.getSortedExposedForKeyDate(LocalDate.now(ZoneOffset.UTC).minusDays(1).atStartOfDay().toInstant(ZoneOffset.UTC).toEpochMilli(),null, (now / releaseBucketDuration)*releaseBucketDuration);
 		assertEquals(0, result.size());
 	}
 


### PR DESCRIPTION
During commenting, I saw that bucketLength and batchLength are the same.
So we searched for a better name and came up with releaseBucketDuration.
It is the time that Exposed Keys are hidden from requests to avoid timing attacks.