### PR TITLE
Add feature to hold back same day TEKs until the next day 

### DIFF
--- a/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/gaen/GAENDataService.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/gaen/GAENDataService.java
@@ -25,11 +25,11 @@ public interface GAENDataService {
 	 */
 	void upsertExposees(List<GaenKey> keys);
 
-		/**
-	 * Upserts (Update or Inserts) the given list of exposed keys, simulating a later insertion (google releases same day keys with rollingPeriod < 144 but apple can't handle that)
+	/**
+	 * Upserts (Update or Inserts) the given list of exposed keys, with delayed release of same day TEKs
 	 * 
 	 * @param keys the list of exposed keys to upsert
-	 * @param delayedReceivedAt the timestamp to use for the "simulated" received at (if null use now rounded to next bucket)
+	 * @param delayedReceivedAt the timestamp to use for the delayed release (if null use now rounded to next bucket)
 	 */
 	void upsertExposeesDelayed(List<GaenKey> keys, OffsetDateTime delayedReceivedAt);
 
@@ -59,6 +59,4 @@ public interface GAENDataService {
 	 * @param retentionPeriod in milliseconds
 	 */
 	void cleanDB(Duration retentionPeriod);
-
-	
 }

--- a/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/gaen/GAENDataService.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/gaen/GAENDataService.java
@@ -11,6 +11,7 @@
 package org.dpppt.backend.sdk.data.gaen;
 
 import java.time.Duration;
+import java.time.OffsetDateTime;
 import java.util.List;
 
 import org.dpppt.backend.sdk.model.gaen.GaenKey;
@@ -23,6 +24,14 @@ public interface GAENDataService {
 	 * @param keys the list of exposed keys to upsert
 	 */
 	void upsertExposees(List<GaenKey> keys);
+
+		/**
+	 * Upserts (Update or Inserts) the given list of exposed keys, simulating a later insertion (google releases same day keys with rollingPeriod < 144 but apple can't handle that)
+	 * 
+	 * @param keys the list of exposed keys to upsert
+	 * @param delayedReceivedAt the timestamp to use for the "simulated" received at (if null use now rounded to next bucket)
+	 */
+	void upsertExposeesDelayed(List<GaenKey> keys, OffsetDateTime delayedReceivedAt);
 
 	/**
 	 * Returns the maximum id of the stored exposed entries for the given batch.
@@ -50,4 +59,6 @@ public interface GAENDataService {
 	 * @param retentionPeriod in milliseconds
 	 */
 	void cleanDB(Duration retentionPeriod);
+
+	
 }

--- a/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/gaen/JDBCGAENDataServiceImpl.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/gaen/JDBCGAENDataServiceImpl.java
@@ -46,6 +46,12 @@ public class JDBCGAENDataServiceImpl implements GAENDataService {
 	@Override
 	@Transactional(readOnly = false)
 	public void upsertExposees(List<GaenKey> gaenKeys) {
+		upsertExposeesDelayed(gaenKeys, null);
+	}
+
+	@Override
+	public void upsertExposeesDelayed(List<GaenKey> gaenKeys, OffsetDateTime delayedReceivedAt) {
+		
 		String sql = null;
 		if (dbType.equals(PGSQL)) {
 			sql = "insert into t_gaen_exposed (key, rolling_start_number, rolling_period, transmission_risk_level, received_at) values (:key, :rolling_start_number, :rolling_period, :transmission_risk_level, :received_at)"
@@ -57,7 +63,8 @@ public class JDBCGAENDataServiceImpl implements GAENDataService {
 		}
 		var parameterList = new ArrayList<MapSqlParameterSource>();
 		var nowMillis = System.currentTimeMillis();
-		var receivedAt = (nowMillis/releaseBucketDuration.toMillis() + 1) * releaseBucketDuration.toMillis() - 1;
+		//if delayedReceivedAt is supplied use it
+		var receivedAt = delayedReceivedAt == null? (nowMillis/releaseBucketDuration.toMillis() + 1) * releaseBucketDuration.toMillis() - 1 : delayedReceivedAt.toInstant().toEpochMilli(); 
 		for (var gaenKey : gaenKeys) {
 			MapSqlParameterSource params = new MapSqlParameterSource();
 			params.addValue("key", gaenKey.getKeyData());
@@ -70,6 +77,7 @@ public class JDBCGAENDataServiceImpl implements GAENDataService {
 		}
 		jt.batchUpdate(sql, parameterList.toArray(new MapSqlParameterSource[0]));
 	}
+
 
 	@Override
 	@Transactional(readOnly = true)
@@ -135,5 +143,4 @@ public class JDBCGAENDataServiceImpl implements GAENDataService {
 		String sqlExposed = "delete from t_gaen_exposed where received_at < :retention_time";
 		jt.update(sqlExposed, params);
 	}
-
 }

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/config/WSBaseConfig.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/config/WSBaseConfig.java
@@ -128,6 +128,8 @@ public abstract class WSBaseConfig implements SchedulingConfigurer, WebMvcConfig
 	String keyIdentifier;
 	@Value("${ws.app.gaen.algorithm:1.2.840.10045.4.3.2}")
 	String gaenAlgorithm;
+	@Value("${ws.app.gaen.delayTodaysKeys: false}")
+	boolean delayTodaysKeys;
 
 	@Autowired(required = false)
 	ValidateRequest requestValidator;
@@ -211,7 +213,7 @@ public abstract class WSBaseConfig implements SchedulingConfigurer, WebMvcConfig
 		}
 		return new GaenController(gaenDataService(), fakeKeyService(), theValidator, gaenSigner(),
 				gaenValidationUtils(), Duration.ofMillis(releaseBucketDuration), Duration.ofMillis(requestTime),
-				Duration.ofMillis(exposedListCacheControl), keyVault.get("nextDayJWT").getPrivate());
+				Duration.ofMillis(exposedListCacheControl), keyVault.get("nextDayJWT").getPrivate(), delayTodaysKeys);
 	}
 
 	@Bean

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/GaenController.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/GaenController.java
@@ -88,9 +88,11 @@ public class GaenController {
 	private final PrivateKey secondDayKey;
 	private final ProtoSignature gaenSigner;
 
+	private final boolean delayTodaysKeys;
+
 	public GaenController(GAENDataService dataService, FakeKeyService fakeKeyService, ValidateRequest validateRequest,
 						  ProtoSignature gaenSigner, ValidationUtils validationUtils, Duration releaseBucketDuration, Duration requestTime,
-						  Duration exposedListCacheControl, PrivateKey secondDayKey) {
+						  Duration exposedListCacheControl, PrivateKey secondDayKey, boolean delayTodaysKeys) {
 		this.dataService = dataService;
 		this.fakeKeyService = fakeKeyService;
 		this.releaseBucketDuration = releaseBucketDuration;
@@ -100,6 +102,7 @@ public class GaenController {
 		this.exposedListCacheControl = exposedListCacheControl;
 		this.secondDayKey = secondDayKey;
 		this.gaenSigner = gaenSigner;
+		this.delayTodaysKeys = delayTodaysKeys;
 	}
 
 	@PostMapping(value = "/exposed")
@@ -129,6 +132,7 @@ public class GaenController {
 		}
 
 		List<GaenKey> nonFakeKeys = new ArrayList<>();
+		List<GaenKey> nonFakeKeysDelayed = new ArrayList<>();
 		for (var key : gaenRequest.getGaenKeys()) {
 			if (!validationUtils.isValidBase64Key(key.getKeyData())) {
 				return () -> new ResponseEntity<>("No valid base64 key", HttpStatus.BAD_REQUEST);
@@ -140,12 +144,22 @@ public class GaenController {
 			}
 
 			if (key.getRollingPeriod().equals(0)) {
-				//currently only android seems to send 0 which can never be valid, since a non used key should not be submitted
-				//default value according to EN is 144, so just set it to that. If we ever get 0 from iOS we should log it, since
-				//this should not happen
+				logger.error("RollingPeriod should NOT be 0, fixing it and using 144");
 				key.setRollingPeriod(GaenKey.GaenKeyDefaultRollingPeriod);
-				if (userAgent.toLowerCase().contains("ios")) {
-					logger.error("Received a rolling period of 0 for an iOS User-Agent");
+			}
+			
+			if(delayTodaysKeys) {
+				//always set rollingStartNumber to default as long as we have to use the apple workaround
+				key.setRollingPeriod(GaenKey.GaenKeyDefaultRollingPeriod);
+
+				var rollingStartNumberDuration = Duration.of(key.getRollingStartNumber(), GaenUnit.TenMinutes).toMillis();
+				var rollingStartNumberInstant = Instant.ofEpochMilli(rollingStartNumberDuration);
+				var rollingStartDate = LocalDate.ofInstant(rollingStartNumberInstant, ZoneOffset.UTC);
+				//if the date is today, delay keys and set rollingPeriod to 144
+				if(LocalDate.now(ZoneOffset.UTC).isEqual(rollingStartDate)) {
+					nonFakeKeysDelayed.add(key);
+					//We already added a key so continue
+					continue;
 				}
 			}
 			nonFakeKeys.add(key);
@@ -157,6 +171,14 @@ public class GaenController {
 		}
 		if (!nonFakeKeys.isEmpty()) {
 			dataService.upsertExposees(nonFakeKeys);
+		}
+		if (!nonFakeKeysDelayed.isEmpty()) {
+			var tomorrowAt2AM = LocalDate.now(ZoneOffset.UTC)
+										.plusDays(1)
+										.atStartOfDay(ZoneOffset.UTC)
+										.plusHours(2)
+								.toOffsetDateTime();
+			dataService.upsertExposeesDelayed(nonFakeKeysDelayed, tomorrowAt2AM);
 		}
 
 		var delayedKeyDateDuration = Duration.of(gaenRequest.getDelayedKeyDate(), GaenUnit.TenMinutes);

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/controller/GaenControllerTest.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/controller/GaenControllerTest.java
@@ -68,6 +68,7 @@ import io.jsonwebtoken.Jwts;
 @ActiveProfiles({"actuator-security"})
 @SpringBootTest(properties = { "ws.app.jwt.publickey=classpath://generated_pub.pem",
 		"logging.level.org.springframework.security=DEBUG", "ws.exposedlist.releaseBucketDuration=7200000", "ws.gaen.randomkeysenabled=true",
+		"ws.app.gaen.delayTodaysKeys=true",
 	"ws.monitor.prometheus.user=prometheus",
 	"ws.monitor.prometheus.password=prometheus",
 	"management.endpoints.enabled-by-default=true",
@@ -124,10 +125,19 @@ public class GaenControllerTest extends BaseControllerTest {
 		gaenKey2.setRollingPeriod(0);
 		gaenKey2.setFake(0);
 		gaenKey2.setTransmissionRiskLevel(0);
+		//third key should be delayed
+		var gaenKey3 = new GaenKey();
+		gaenKey3.setRollingStartNumber((int) Duration.ofMillis(LocalDate.now(ZoneOffset.UTC).atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli())
+				.dividedBy(Duration.ofMinutes(10)));
+		gaenKey3.setKeyData(Base64.getEncoder().encodeToString("testKey32Bytes03".getBytes("UTF-8")));
+		gaenKey3.setRollingPeriod(120);
+		gaenKey3.setFake(0);
+		gaenKey3.setTransmissionRiskLevel(0);
 		List<GaenKey> exposedKeys = new ArrayList<>();
 		exposedKeys.add(gaenKey1);
 		exposedKeys.add(gaenKey2);
-		for (int i = 0; i < n-2; i++) {
+		exposedKeys.add(gaenKey3);
+		for (int i = 0; i < n-3; i++) {
 			var tmpKey = new GaenKey();
 			tmpKey.setRollingStartNumber(
 					(int) Duration.ofMillis(now).dividedBy(Duration.ofMinutes(10)));
@@ -172,6 +182,11 @@ public class GaenControllerTest extends BaseControllerTest {
 
 		result = gaenDataService.getSortedExposedForKeyDate(LocalDate.now(ZoneOffset.UTC).minusDays(1).atStartOfDay().toInstant(ZoneOffset.UTC).toEpochMilli(),null, (now / releaseBucketDuration)*releaseBucketDuration);
 		assertEquals(0, result.size());
+
+		//third key should be released tomorrow
+		var tomorrow2AM = LocalDate.now(ZoneOffset.UTC).plusDays(1).atStartOfDay().plusHours(2).plusSeconds(1);
+		result = gaenDataService.getSortedExposedForKeyDate(LocalDate.now(ZoneOffset.UTC).atStartOfDay().toInstant(ZoneOffset.UTC).toEpochMilli(),null, tomorrow2AM.toInstant(ZoneOffset.UTC).toEpochMilli());
+		assertEquals(1, result.size());
 	}
 
 	@Test


### PR DESCRIPTION
This pull-request adds a feature (with a flag) which allows to hold back same day TEKs until the next day. This provides a mechanism to be compatible with EN 1.0 in iOS 13.5.x (which ignores all TEKs with rollingPeriod not equals 144). When turned on, keys with rollingStartNumber of today will be held back until 02:00 UTC of the next day. Additionally the rolling period of this key will be increased to 144.

After enough users upgrade iOS 13.6 this feature should get disabled. 

