### PR TITLE
Move normalizeRequestTime to UTCInstant

### DIFF
--- a/dpppt-backend-sdk/dpppt-backend-sdk-model/src/main/java/org/dpppt/backend/sdk/utils/DurationExpiredException.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-model/src/main/java/org/dpppt/backend/sdk/utils/DurationExpiredException.java
@@ -1,0 +1,8 @@
+package org.dpppt.backend.sdk.utils;
+
+/** Indicates that the requested maximum duration already expired. */
+public class DurationExpiredException extends Exception {
+  public DurationExpiredException(String errorMessage) {
+    super(errorMessage);
+  }
+}

--- a/dpppt-backend-sdk/dpppt-backend-sdk-model/src/main/java/org/dpppt/backend/sdk/utils/UTCInstant.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-model/src/main/java/org/dpppt/backend/sdk/utils/UTCInstant.java
@@ -229,4 +229,24 @@ public class UTCInstant {
   public boolean isAfterToday() {
     return this.isAfterDateOf(UTCInstant.now());
   }
+
+  /**
+   * To avoid timing attacks where the duration of the API is used to infer what the user requested,
+   * all requests that change the database call this method to have the same duration, so an outside
+   * attacker cannot infer anything on the response time. If the caller already spent too much time,
+   * an exception is thrown.
+   *
+   * @param totalDuration how long the total duration should be
+   * @throws InterruptedException if the sleep failed
+   * @throws DurationExpiredException if the duration already passed
+   */
+  public void normalizeDuration(Duration totalDuration)
+      throws InterruptedException, DurationExpiredException {
+    Duration timeFillUp = totalDuration.minus(UTCInstant.now().getDuration(this));
+    if (timeFillUp.isNegative()) {
+      throw new DurationExpiredException("Duration of call was longer than requestDuration");
+    } else {
+      Thread.sleep(timeFillUp.toMillis());
+    }
+  }
 }

--- a/dpppt-backend-sdk/dpppt-backend-sdk-model/src/test/java/org/dpppt/backend/sdk/utils/UTCInstantTest.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-model/src/test/java/org/dpppt/backend/sdk/utils/UTCInstantTest.java
@@ -1,0 +1,25 @@
+package org.dpppt.backend.sdk.utils;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+class UTCInstantTest {
+
+  @Test
+  /*
+   * Make sure that the duration is kept, and that it refuses to sleep if the duration already passed.
+   */
+  void normalizeDuration() throws Exception {
+    UTCInstant now = UTCInstant.now();
+    Duration minimumDuration = Duration.ofSeconds(1);
+    UTCInstant oneSecondLater = now.plus(minimumDuration);
+    assertTrue(UTCInstant.now().isBeforeEpochMillisOf(oneSecondLater));
+
+    now.normalizeDuration(minimumDuration);
+    assertFalse(UTCInstant.now().isBeforeEpochMillisOf(oneSecondLater));
+
+    assertThrows(DurationExpiredException.class, () -> now.normalizeDuration(minimumDuration));
+  }
+}


### PR DESCRIPTION
Move the method `normalizeRequestTime` to `UTCInstant` so that it can be unit-tested.
