### PR TITLE
Make sure that no random key is added that is valid in the future

### DIFF
--- a/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/gaen/FakeKeyService.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/gaen/FakeKeyService.java
@@ -51,9 +51,9 @@ public class FakeKeyService {
 						.dividedBy(GaenUnit.TenMinutes.getDuration());
 
 				int rollingPeriod = 144;
-				// make sure that no key is added that is valid in the future.
+				// make sure that no keys are added that are valid today
 				if (tmpDate.equals(currentKeyDate)) {
-					rollingPeriod = 0;
+					continue;
 				}
 
 				var key = new GaenKey(Base64.getEncoder().encodeToString(keyData), keyGAENTime, rollingPeriod, 0);

--- a/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/gaen/FakeKeyService.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/gaen/FakeKeyService.java
@@ -3,6 +3,7 @@ package org.dpppt.backend.sdk.data.gaen;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZoneOffset;
@@ -67,8 +68,13 @@ public class FakeKeyService {
 		if (!isEnabled) {
 			return keys;
 		}
+		var today = LocalDate.now(ZoneOffset.UTC);
+		var keyLocalDate = LocalDate.ofInstant(Instant.ofEpochMilli(keyDate), ZoneOffset.UTC);
+		if (today.isEqual(keyLocalDate)) {
+			return keys;
+		}
 		var fakeKeys = this.dataService.getSortedExposedForKeyDate(keyDate, publishedafter,
-				LocalDate.now().plusDays(1).atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli());
+						today.plusDays(1).atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli());
 
 		keys.addAll(fakeKeys);
 		return keys;

--- a/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/gaen/FakeKeyService.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/gaen/FakeKeyService.java
@@ -16,7 +16,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class FakeKeyService {
-	
+
 	private final GAENDataService dataService;
 	private final Integer minNumOfKeys;
 	private final SecureRandom random;
@@ -49,7 +49,14 @@ public class FakeKeyService {
 				random.nextBytes(keyData);
 				var keyGAENTime = (int) Duration.ofSeconds(tmpDate.toEpochSecond(LocalTime.MIDNIGHT, ZoneOffset.UTC))
 						.dividedBy(GaenUnit.TenMinutes.getDuration());
-				var key = new GaenKey(Base64.getEncoder().encodeToString(keyData), keyGAENTime, 144, 0);
+
+				int rollingPeriod = 144;
+				// make sure that no key is added that is valid in the future.
+				if (tmpDate.equals(currentKeyDate)) {
+					rollingPeriod = 0;
+				}
+
+				var key = new GaenKey(Base64.getEncoder().encodeToString(keyData), keyGAENTime, rollingPeriod, 0);
 				keys.add(key);
 			}
 			this.dataService.upsertExposees(keys);

--- a/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/gaen/FakeKeyService.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/gaen/FakeKeyService.java
@@ -50,18 +50,12 @@ public class FakeKeyService {
 				var keyGAENTime = (int) Duration.ofSeconds(tmpDate.toEpochSecond(LocalTime.MIDNIGHT, ZoneOffset.UTC))
 						.dividedBy(GaenUnit.TenMinutes.getDuration());
 
-				int rollingPeriod = 144;
-				// make sure that no keys are added that are valid today
-				if (tmpDate.equals(currentKeyDate)) {
-					continue;
-				}
-
-				var key = new GaenKey(Base64.getEncoder().encodeToString(keyData), keyGAENTime, rollingPeriod, 0);
+				var key = new GaenKey(Base64.getEncoder().encodeToString(keyData), keyGAENTime, GaenKey.GaenKeyDefaultRollingPeriod, 0);
 				keys.add(key);
 			}
 			this.dataService.upsertExposees(keys);
 			tmpDate = tmpDate.plusDays(1);
-		} while (tmpDate.isBefore(currentKeyDate.plusDays(1)));
+		} while (tmpDate.isBefore(currentKeyDate));
 	}
 
 	private void deleteAllKeys() {

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/controller/GaenControllerTest.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/controller/GaenControllerTest.java
@@ -989,13 +989,12 @@ public class GaenControllerTest extends BaseControllerTest {
 	
 	@Test
 	@Transactional(transactionManager = "testTransactionManager")
-	public void testNonEmptyResponseAndCurrentDayRandomKeyRollingPeriod() throws Exception {
+	public void testTodayWeDontHaveKeys() throws Exception {
 		MockHttpServletResponse response = mockMvc
 				.perform(get("/v1/gaen/exposed/"
 						+ LocalDate.now(ZoneOffset.UTC).atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli())
 								.header("User-Agent", "MockMVC"))
-				.andExpect(status().isOk()).andReturn().getResponse();
-		verifyZipResponse(response, 10, 0);
+				.andExpect(status().is(204)).andReturn().getResponse();
 	}
 
 	// @Test


### PR DESCRIPTION
Ensure that we do not insert random (fake) keys for today, which are still valid for today. 

Replaces https://github.com/DP-3T/dp3t-sdk-backend/pull/198