### PR TITLE
Hotfix/v1.1.1 (CVE-2020-15957)

### DIFF
--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/security/DPPTJwtDecoder.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/security/DPPTJwtDecoder.java
@@ -36,7 +36,7 @@ public class DPPTJwtDecoder implements JwtDecoder {
 	@Override
 	public Jwt decode(String token) throws JwtException {
 		try {
-			var t = parser.parse(token);
+			var t = parser.parseClaimsJws(token);
 
 			var headers = t.getHeader();
 			var claims = (Claims) t.getBody();

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/controller/BaseControllerTest.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/controller/BaseControllerTest.java
@@ -143,5 +143,14 @@ public abstract class BaseControllerTest {
 				.setSubject("test-subject" + OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).toString()).setExpiration(Date.from(expiresAt.toInstant()))
 				.setIssuedAt(Date.from(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).toInstant())).signWith((Key) privateKey).compact();
 	}
+	protected String createMaliciousToken(OffsetDateTime expiresAt) {
+		Claims claims = Jwts.claims();
+		claims.put("scope", "exposed");
+		claims.put("onset", "2020-04-20");
+		claims.put("fake", "0");
+		return Jwts.builder().setClaims(claims).setId(UUID.randomUUID().toString())
+				.setSubject("test-subject" + OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).toString()).setExpiration(Date.from(expiresAt.toInstant()))
+				.setIssuedAt(Date.from(OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.UTC).toInstant())).compact();
+	}
 
 }


### PR DESCRIPTION
When dp3t-sdk-backend is configured to check a JWT before uploading/publishing keys, it was possible to skip the signature check by providing a JWT token with `"alg":"none"`.

This addresses CVE-2020-15957 (thanks to @MrSuicideParrot)