### PR TITLE
Documentation/clarify docker build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ docker:
 	cp dpppt-backend-sdk/dpppt-backend-sdk-ws/target/dpppt-backend-sdk-ws.jar ws-sdk/ws/bin/dpppt-backend-sdk-ws-1.0.0.jar
 	docker build -t dp3t-docker ws-sdk/
 	@printf '\033[33m DO NOT USE THIS IN PRODUCTION \033[0m \n'
-	@printf '\033[32m docker run -p 8080:8080 -v `pwd`/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/resources/logback.xml:/home/ws/conf/dpppt-backend-sdk-ws-logback.xml -v `pwd`/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/resources/application.properties:/home/ws/conf/dpppt-backend-sdk-ws.properties dp3t-docker \033[0m'
+	@printf "\033[32m docker run -p 8080:8080 -v $(PWD)/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/resources/logback.xml:/home/ws/conf/dpppt-backend-sdk-ws-logback.xml -v $(PWD)/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/resources/application.properties:/home/ws/conf/dpppt-backend-sdk-ws.properties dp3t-docker \033[0m\n"
 	
 
 

--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,12 @@ all1: clean updateproject updatedoc swagger la la2 la3
 no: clean updateproject updatedoc swagger la la2 
 docker-build: updateproject docker
 doc: updatedoc swagger la la2 la3
+test: clean run-test
+run-test:
+	mvn -f dpppt-backend-sdk/pom.xml test
 
 updateproject:
-	mvn -f dpppt-backend-sdk/pom.xml install
+	mvn -f dpppt-backend-sdk/pom.xml install -DskipTests
 
 updatedoc:
 	mvn -f dpppt-backend-sdk/pom.xml install -Dmaven.test.skip=true
@@ -37,8 +40,10 @@ show:
 	cd documentation; open $(FILE_NAME).pdf &
 
 docker:
-	cp dpppt-backend-sdk/dpppt-backend-sdk-ws/target/dpppt-backend-sdk-ws-1.0.0-SNAPSHOT.jar ws-sdk/ws/bin/dpppt-backend-sdk-ws-1.0.0.jar
-	docker build -t 979586646521.dkr.ecr.eu-west-1.amazonaws.com/ubiquevscovid19-ws:test ws-sdk/
+	cp dpppt-backend-sdk/dpppt-backend-sdk-ws/target/dpppt-backend-sdk-ws.jar ws-sdk/ws/bin/dpppt-backend-sdk-ws-1.0.0.jar
+	docker build -t dp3t-docker ws-sdk/
+	@printf '\033[33m DO NOT USE THIS IN PRODUCTION \033[0m \n'
+	@printf '\033[32m docker run -p 8080:8080 -v `pwd`/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/resources/logback.xml:/home/ws/conf/dpppt-backend-sdk-ws-logback.xml -v `pwd`/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/resources/application.properties:/home/ws/conf/dpppt-backend-sdk-ws.properties dp3t-docker \033[0m'
 	
 
 

--- a/README.md
+++ b/README.md
@@ -218,3 +218,10 @@ To build the docker image run
 
 ```bash
 make docker-build
+```
+
+This will build the jar and copy it into the `ws-sdk/ws/bin` folder, from where it is then added to the container image. The image will be tagged as `dp3t-docker`. 
+
+An example `logback.xml` is found in the `resources` folder for the `dpppt-backend-sdk-ws` Java module.
+
+An example `application.properties` file is found at the same location. Just make sure the configuration matches with your deployment (c.f. `WSBaseConfig` for possible properties and `WSCloudBaseConfig` for some `CloudFoundry` specific properties) 

--- a/README.md
+++ b/README.md
@@ -224,4 +224,6 @@ This will build the jar and copy it into the `ws-sdk/ws/bin` folder, from where 
 
 An example `logback.xml` is found in the `resources` folder for the `dpppt-backend-sdk-ws` Java module.
 
-An example `application.properties` file is found at the same location. Just make sure the configuration matches with your deployment (c.f. `WSBaseConfig` for possible properties and `WSCloudBaseConfig` for some `CloudFoundry` specific properties) 
+An example `application.properties` file is found at the same location. 
+Just make sure the configuration matches with your deployment (c.f. `WSBaseConfig` for possible properties
+and `WSCloudBaseConfig` for some `CloudFoundry` specific properties) 

--- a/README.md
+++ b/README.md
@@ -220,7 +220,8 @@ To build the docker image run
 make docker-build
 ```
 
-This will build the jar and copy it into the `ws-sdk/ws/bin` folder, from where it is then added to the container image. The image will be tagged as `dp3t-docker`. 
+This will build the jar and copy it into the `ws-sdk/ws/bin` folder, from where it is then added to the container image.
+The image will be tagged as `dp3t-docker`. 
 
 An example `logback.xml` is found in the `resources` folder for the `dpppt-backend-sdk-ws` Java module.
 

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/resources/application.properties
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/resources/application.properties
@@ -8,22 +8,22 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 
-spring.profiles.active=prod
+spring.profiles.active=dev
 management.endpoints.enabled-by-default=false
 server.error.whitelabel.enabled=true
 #-------------------------------------------------------------------------------
 # JDBC Config
 #-------------------------------------------------------------------------------
 # local
-datasource.url=jdbc:postgresql://localhost:5432/dpppt
-datasource.username=dpppt
-datasource.password=dpppt
-datasource.driverClassName=org.postgresql.ds.PGSimpleDataSource
-datasource.failFast=true
-datasource.maximumPoolSize=5
-datasource.maxLifetime=1700000
-datasource.idleTimeout=600000
-datasource.connectionTimeout=30000
+# datasource.url=jdbc:postgresql://localhost:5432/dpppt
+# datasource.username=dpppt
+# datasource.password=dpppt
+# datasource.driverClassName=org.postgresql.ds.PGSimpleDataSource
+# datasource.failFast=true
+# datasource.maximumPoolSize=5
+# datasource.maxLifetime=1700000
+# datasource.idleTimeout=600000
+# datasource.connectionTimeout=30000
 
 #ws.exposedlist.cachecontrol=5
 ws.app.source=org.dpppt.demo


### PR DESCRIPTION
Closes: https://github.com/DP-3T/dp3t-sdk-backend/issues/196

- Makefile has now a specific test target
- Build targets skip tests so if you still want the test to be run use `make test`
- The `docker-build` target now prints the docker run command
- The default application.properties file uses `dev` and nothing special (should run everywhere)

