### PR TITLE
[WIP] Feature/get exposed sql filters

### DIFF
--- a/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/gaen/FakeKeyService.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/gaen/FakeKeyService.java
@@ -40,8 +40,8 @@ public class FakeKeyService {
 
   public void updateFakeKeys() {
     deleteAllKeys();
-    var currentKeyDate = UTCInstant.now();
-    var tmpDate = currentKeyDate.minusDays(retentionPeriod.toDays());
+    var currentKeyDate = UTCInstant.today();
+    var tmpDate = currentKeyDate.minusDays(retentionPeriod.toDays()).atStartOfDay();
     logger.debug("Fill Fake keys. Start: " + currentKeyDate + " End: " + tmpDate);
     do {
       var keys = new ArrayList<GaenKey>();

--- a/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/gaen/FakeKeyService.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/gaen/FakeKeyService.java
@@ -64,18 +64,18 @@ public class FakeKeyService {
   }
 
   public List<GaenKey> fillUpKeys(
-      List<GaenKey> keys, UTCInstant publishedafter, UTCInstant keyDate) {
+      List<GaenKey> keys, UTCInstant publishedafter, UTCInstant keyDate, UTCInstant now) {
     if (!isEnabled) {
       return keys;
     }
-    var today = UTCInstant.today();
+    var today = now.atStartOfDay();
     var keyLocalDate = keyDate.atStartOfDay();
     if (today.hasSameDateAs(keyLocalDate)) {
       return keys;
     }
     var fakeKeys =
         this.dataService.getSortedExposedForKeyDate(
-            keyDate, publishedafter, UTCInstant.today().plusDays(1));
+            keyDate, publishedafter, UTCInstant.today().plusDays(1), now);
 
     keys.addAll(fakeKeys);
     return keys;

--- a/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/gaen/GAENDataService.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/gaen/GAENDataService.java
@@ -39,24 +39,26 @@ public interface GAENDataService {
   /**
    * Returns the maximum id of the stored exposed entries for the given batch.
    *
-   * @param keyDate in milliseconds since Unix epoch (1970-01-01)
-   * @param publishedAfter in milliseconds since Unix epoch
-   * @param publishedUntil in milliseconds since Unix epoch
+   * @param keyDate must be midnight UTC
+   * @param publishedAfter when publication should start
+   * @param publishedUntil last publication
+   * @param now the start of the query
    * @return the maximum id of the stored exposed entries for the given batch
    */
   int getMaxExposedIdForKeyDate(
-      UTCInstant keyDate, UTCInstant publishedAfter, UTCInstant publishedUntil);
+      UTCInstant keyDate, UTCInstant publishedAfter, UTCInstant publishedUntil, UTCInstant now);
 
   /**
    * Returns all exposeed keys for the given batch.
    *
-   * @param keyDate in milliseconds since Unix epoch (1970-01-01)
-   * @param publishedAfter in milliseconds since Unix epoch
-   * @param publishedUntil in milliseconds since Unix epoch
+   * @param keyDate must be midnight UTC
+   * @param publishedAfter when publication should start
+   * @param publishedUntil last publication
+   * @param now the start of the query
    * @return all exposeed keys for the given batch
    */
   List<GaenKey> getSortedExposedForKeyDate(
-      UTCInstant keyDate, UTCInstant publishedAfter, UTCInstant publishedUntil);
+      UTCInstant keyDate, UTCInstant publishedAfter, UTCInstant publishedUntil, UTCInstant now);
 
   /**
    * deletes entries older than retentionperiod

--- a/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/gaen/GAENDataService.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/gaen/GAENDataService.java
@@ -37,7 +37,9 @@ public interface GAENDataService {
   void upsertExposeesDelayed(List<GaenKey> keys, UTCInstant delayedReceivedAt, UTCInstant now);
 
   /**
-   * Returns all exposeed keys for the given batch.
+   * Returns all exposeed keys for the given batch, where a batch is parametrized with keyDate (for
+   * which day was the key used) publishedAfter/publishedUntil (when was the key published) and now
+   * (has the key expired or not, based on rollingStartNumber and rollingPeriod).
    *
    * @param keyDate must be midnight UTC
    * @param publishedAfter when publication should start

--- a/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/gaen/GAENDataService.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/gaen/GAENDataService.java
@@ -37,18 +37,6 @@ public interface GAENDataService {
   void upsertExposeesDelayed(List<GaenKey> keys, UTCInstant delayedReceivedAt, UTCInstant now);
 
   /**
-   * Returns the maximum id of the stored exposed entries for the given batch.
-   *
-   * @param keyDate must be midnight UTC
-   * @param publishedAfter when publication should start
-   * @param publishedUntil last publication
-   * @param now the start of the query
-   * @return the maximum id of the stored exposed entries for the given batch
-   */
-  int getMaxExposedIdForKeyDate(
-      UTCInstant keyDate, UTCInstant publishedAfter, UTCInstant publishedUntil, UTCInstant now);
-
-  /**
    * Returns all exposeed keys for the given batch.
    *
    * @param keyDate must be midnight UTC

--- a/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/gaen/JDBCGAENDataServiceImpl.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/gaen/JDBCGAENDataServiceImpl.java
@@ -103,10 +103,11 @@ public class JDBCGAENDataServiceImpl implements GAENDataService {
             + " rolling_start_number >= :rollingPeriodStartNumberStart"
             + " and rolling_start_number < :rollingPeriodStartNumberEnd"
             + " and received_at < :publishedUntil";
-
+    // we need to subtract the time skew since we want to release it iff rolling_start_number +
+    // rolling_period + timeSkew < NOW
     params.addValue(
         "maxAllowedStartNumber",
-        now.roundToBucketStart(releaseBucketDuration).plus(timeSkew).get10MinutesSince1970());
+        now.roundToBucketStart(releaseBucketDuration).minus(timeSkew).get10MinutesSince1970());
     sql += " and rolling_start_number < :maxAllowedStartNumber";
 
     if (publishedAfter != null) {
@@ -136,10 +137,11 @@ public class JDBCGAENDataServiceImpl implements GAENDataService {
             + " from t_gaen_exposed where rolling_start_number >= :rollingPeriodStartNumberStart"
             + " and rolling_start_number < :rollingPeriodStartNumberEnd and received_at <"
             + " :publishedUntil";
-
+    // we need to subtract the time skew since we want to release it iff rolling_start_number +
+    // rolling_period + timeSkew < NOW
     params.addValue(
         "maxAllowedStartNumber",
-        now.roundToBucketStart(releaseBucketDuration).plus(timeSkew).get10MinutesSince1970());
+        now.roundToBucketStart(releaseBucketDuration).minus(timeSkew).get10MinutesSince1970());
     sql += " and rolling_start_number + rolling_period < :maxAllowedStartNumber";
 
     if (publishedAfter != null) {

--- a/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/gaen/JDBCGAENDataServiceImpl.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/gaen/JDBCGAENDataServiceImpl.java
@@ -98,12 +98,11 @@ public class JDBCGAENDataServiceImpl implements GAENDataService {
             + " rolling_start_number >= :rollingPeriodStartNumberStart"
             + " and rolling_start_number < :rollingPeriodStartNumberEnd"
             + " and received_at < :publishedUntil";
-    if (now != null) {
-      params.addValue(
-          "maxAllowedStartNumber",
-          now.roundToBucketStart(releaseBucketDuration).plusHours(2).get10MinutesSince1970());
-      sql += " and rolling_start_number < :maxAllowedStartNumber";
-    }
+
+    params.addValue(
+        "maxAllowedStartNumber",
+        now.roundToBucketStart(releaseBucketDuration).plusHours(2).get10MinutesSince1970());
+    sql += " and rolling_start_number < :maxAllowedStartNumber";
 
     if (publishedAfter != null) {
       params.addValue("publishedAfter", publishedAfter.getDate());
@@ -133,12 +132,10 @@ public class JDBCGAENDataServiceImpl implements GAENDataService {
             + " and rolling_start_number < :rollingPeriodStartNumberEnd and received_at <"
             + " :publishedUntil";
 
-    if (now != null) {
-      params.addValue(
-          "maxAllowedStartNumber",
-          now.roundToBucketStart(releaseBucketDuration).plusHours(2).get10MinutesSince1970());
-      sql += " and rolling_start_number + rolling_period < :maxAllowedStartNumber";
-    }
+    params.addValue(
+        "maxAllowedStartNumber",
+        now.roundToBucketStart(releaseBucketDuration).plusHours(2).get10MinutesSince1970());
+    sql += " and rolling_start_number + rolling_period < :maxAllowedStartNumber";
 
     if (publishedAfter != null) {
       params.addValue("publishedAfter", publishedAfter.getDate());

--- a/dpppt-backend-sdk/dpppt-backend-sdk-data/src/test/java/org/dpppt/backend/sdk/data/config/DPPPTDataServiceConfig.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-data/src/test/java/org/dpppt/backend/sdk/data/config/DPPPTDataServiceConfig.java
@@ -36,6 +36,9 @@ public class DPPPTDataServiceConfig {
   @Value("${ws.exposedlist.releaseBucketDuration: 7200000}")
   long releaseBucketDuration;
 
+  @Value("${ws.gaen.timeskew: PT2h}")
+  Duration timeSkew;
+
   @Autowired DataSource dataSource;
 
   @Bean
@@ -56,7 +59,7 @@ public class DPPPTDataServiceConfig {
   @Bean
   public GAENDataService gaenDataService() {
     return new JDBCGAENDataServiceImpl(
-        dbType, dataSource, Duration.ofMillis(releaseBucketDuration));
+        dbType, dataSource, Duration.ofMillis(releaseBucketDuration), timeSkew);
   }
 
   @Bean
@@ -67,7 +70,7 @@ public class DPPPTDataServiceConfig {
   @Bean
   public GAENDataService fakeService() {
     return new JDBCGAENDataServiceImpl(
-        "hsql", fakeDataSource(), Duration.ofMillis(releaseBucketDuration));
+        "hsql", fakeDataSource(), Duration.ofMillis(releaseBucketDuration), timeSkew);
   }
 
   @Bean

--- a/dpppt-backend-sdk/dpppt-backend-sdk-data/src/test/java/org/dpppt/backend/sdk/data/config/DPPPTDataServiceConfig.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-data/src/test/java/org/dpppt/backend/sdk/data/config/DPPPTDataServiceConfig.java
@@ -36,8 +36,8 @@ public class DPPPTDataServiceConfig {
   @Value("${ws.exposedlist.releaseBucketDuration: 7200000}")
   long releaseBucketDuration;
 
-  @Value("${ws.gaen.timeskew: PT2h}")
-  Duration timeSkew;
+  // @Value("${ws.app.gaen.timeskew:PT2h}")
+  Duration timeSkew = Duration.ofHours(2);
 
   @Autowired DataSource dataSource;
 

--- a/dpppt-backend-sdk/dpppt-backend-sdk-data/src/test/java/org/dpppt/backend/sdk/data/gaen/GaenDataServiceTest.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-data/src/test/java/org/dpppt/backend/sdk/data/gaen/GaenDataServiceTest.java
@@ -109,5 +109,6 @@ public class GaenDataServiceTest {
     returnedKeys =
         gaenDataService.getSortedExposedForKeyDate(UTCInstant.today(), null, publishedUntil, now);
     assertEquals(1, returnedKeys.size());
+    UTCInstant.resetClock();
   }
 }

--- a/dpppt-backend-sdk/dpppt-backend-sdk-data/src/test/java/org/dpppt/backend/sdk/data/gaen/GaenDataServiceTest.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-data/src/test/java/org/dpppt/backend/sdk/data/gaen/GaenDataServiceTest.java
@@ -72,10 +72,13 @@ public class GaenDataServiceTest {
 
   @Test
   public void testNoEarlyRelease() throws Exception {
-    Clock twoOClock = Clock.fixed(UTCInstant.today().plusHours(2).getInstant(), ZoneOffset.UTC);
-    Clock elevenOClock = Clock.fixed(UTCInstant.today().plusHours(11).getInstant(), ZoneOffset.UTC);
+    var outerNow = UTCInstant.now();
+    Clock twoOClock =
+        Clock.fixed(outerNow.atStartOfDay().plusHours(2).getInstant(), ZoneOffset.UTC);
+    Clock elevenOClock =
+        Clock.fixed(outerNow.atStartOfDay().plusHours(11).getInstant(), ZoneOffset.UTC);
     Clock fourteenOClock =
-        Clock.fixed(UTCInstant.today().plusHours(14).getInstant(), ZoneOffset.UTC);
+        Clock.fixed(outerNow.atStartOfDay().plusHours(14).getInstant(), ZoneOffset.UTC);
 
     try (var now = UTCInstant.setClock(twoOClock)) {
       var tmpKey = new GaenKey();
@@ -96,7 +99,7 @@ public class GaenDataServiceTest {
     try (var now = UTCInstant.setClock(elevenOClock)) {
       UTCInstant publishedUntil = now.roundToNextBucket(BUCKET_LENGTH).plusMinutes(1);
       var returnedKeys =
-          gaenDataService.getSortedExposedForKeyDate(UTCInstant.today(), null, publishedUntil, now);
+          gaenDataService.getSortedExposedForKeyDate(now.atStartOfDay(), null, publishedUntil, now);
       assertEquals(0, returnedKeys.size());
     }
 
@@ -104,7 +107,7 @@ public class GaenDataServiceTest {
     try (var now = UTCInstant.setClock(fourteenOClock)) {
       UTCInstant publishedUntil = now.roundToNextBucket(BUCKET_LENGTH);
       var returnedKeys =
-          gaenDataService.getSortedExposedForKeyDate(UTCInstant.today(), null, publishedUntil, now);
+          gaenDataService.getSortedExposedForKeyDate(now.atStartOfDay(), null, publishedUntil, now);
       assertEquals(1, returnedKeys.size());
     }
   }

--- a/dpppt-backend-sdk/dpppt-backend-sdk-data/src/test/java/org/dpppt/backend/sdk/data/gaen/GaenDataServiceTest.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-data/src/test/java/org/dpppt/backend/sdk/data/gaen/GaenDataServiceTest.java
@@ -64,7 +64,7 @@ public class GaenDataServiceTest {
 
     var returnedKeys =
         gaenDataService.getSortedExposedForKeyDate(
-            UTCInstant.today().minusDays(1), null, publishedUntil, now);
+            UTCInstant.today().minusDays(1), null, publishedUntil, now.plusMinutes(1));
 
     assertEquals(keys.size(), returnedKeys.size());
     assertEquals(keys.get(1).getKeyData(), returnedKeys.get(0).getKeyData());

--- a/dpppt-backend-sdk/dpppt-backend-sdk-data/src/test/java/org/dpppt/backend/sdk/data/gaen/GaenDataServiceTest.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-data/src/test/java/org/dpppt/backend/sdk/data/gaen/GaenDataServiceTest.java
@@ -103,7 +103,7 @@ public class GaenDataServiceTest {
 
     // twelve O'clock release the key
     UTCInstant.setClock(fourteenOClock);
-    now = UTCInstant.now().plusMinutes(1);
+    now = UTCInstant.now();
 
     publishedUntil = now.roundToNextBucket(BUCKET_LENGTH);
     returnedKeys =

--- a/dpppt-backend-sdk/dpppt-backend-sdk-data/src/test/java/org/dpppt/backend/sdk/data/gaen/GaenDataServiceTest.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-data/src/test/java/org/dpppt/backend/sdk/data/gaen/GaenDataServiceTest.java
@@ -61,7 +61,7 @@ public class GaenDataServiceTest {
 
     var returnedKeys =
         gaenDataService.getSortedExposedForKeyDate(
-            UTCInstant.today().minusDays(1), null, publishedUntil);
+            UTCInstant.today().minusDays(1), null, publishedUntil, now);
 
     assertEquals(keys.size(), returnedKeys.size());
     assertEquals(keys.get(1).getKeyData(), returnedKeys.get(0).getKeyData());

--- a/dpppt-backend-sdk/dpppt-backend-sdk-data/src/test/java/org/dpppt/backend/sdk/data/gaen/GaenDataServiceTest.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-data/src/test/java/org/dpppt/backend/sdk/data/gaen/GaenDataServiceTest.java
@@ -43,14 +43,14 @@ public class GaenDataServiceTest {
     var tmpKey = new GaenKey();
     tmpKey.setRollingStartNumber(
         (int) UTCInstant.today().minus(Duration.ofDays(1)).get10MinutesSince1970());
-    tmpKey.setKeyData(Base64.getEncoder().encodeToString("testKey32Bytes--".getBytes("UTF-8")));
+    tmpKey.setKeyData(Base64.getEncoder().encodeToString("testKey32Bytes01".getBytes("UTF-8")));
     tmpKey.setRollingPeriod(144);
     tmpKey.setFake(0);
     tmpKey.setTransmissionRiskLevel(0);
     var tmpKey2 = new GaenKey();
     tmpKey2.setRollingStartNumber(
         (int) UTCInstant.today().minus(Duration.ofDays(1)).get10MinutesSince1970());
-    tmpKey2.setKeyData(Base64.getEncoder().encodeToString("testKey33Bytes--".getBytes("UTF-8")));
+    tmpKey2.setKeyData(Base64.getEncoder().encodeToString("testKey32Bytes02".getBytes("UTF-8")));
     tmpKey2.setRollingPeriod(144);
     tmpKey2.setFake(0);
     tmpKey2.setTransmissionRiskLevel(0);
@@ -64,7 +64,7 @@ public class GaenDataServiceTest {
 
     var returnedKeys =
         gaenDataService.getSortedExposedForKeyDate(
-            UTCInstant.today().minusDays(1), null, publishedUntil, now.plusMinutes(1));
+            UTCInstant.today().minusDays(1), null, publishedUntil, now);
 
     assertEquals(keys.size(), returnedKeys.size());
     assertEquals(keys.get(1).getKeyData(), returnedKeys.get(0).getKeyData());

--- a/dpppt-backend-sdk/dpppt-backend-sdk-data/src/test/java/org/dpppt/backend/sdk/data/gaen/PostgresGaenDataServiceTest.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-data/src/test/java/org/dpppt/backend/sdk/data/gaen/PostgresGaenDataServiceTest.java
@@ -78,20 +78,20 @@ public class PostgresGaenDataServiceTest {
     var keysUntilToday = today.minusDays(21);
 
     var keys = new ArrayList<GaenKey>();
-    var emptyList = fakeKeyService.fillUpKeys(keys, null, noKeyAtThisDate);
+    var emptyList = fakeKeyService.fillUpKeys(keys, null, noKeyAtThisDate, now);
     assertEquals(0, emptyList.size());
     do {
       keys.clear();
-      var list = fakeKeyService.fillUpKeys(keys, null, keysUntilToday);
+      var list = fakeKeyService.fillUpKeys(keys, null, keysUntilToday, now);
 
       assertEquals(10, list.size());
-      list = fakeKeyService.fillUpKeys(keys, UTCInstant.now().plusHours(3), keysUntilToday);
+      list = fakeKeyService.fillUpKeys(keys, UTCInstant.now().plusHours(3), keysUntilToday, now);
       assertEquals(10, list.size());
       keysUntilToday = keysUntilToday.plusDays(1);
     } while (keysUntilToday.isBeforeDateOf(today));
 
     keys.clear();
-    emptyList = fakeKeyService.fillUpKeys(keys, null, noKeyAtThisDate);
+    emptyList = fakeKeyService.fillUpKeys(keys, null, noKeyAtThisDate, now);
     assertEquals(0, emptyList.size());
   }
 
@@ -149,13 +149,13 @@ public class PostgresGaenDataServiceTest {
         receivedAt.getInstant(), receivedAt.minusDays(1).getInstant(), key);
 
     List<GaenKey> sortedExposedForDay =
-        gaenDataService.getSortedExposedForKeyDate(receivedAt.minusDays(1), null, now);
+        gaenDataService.getSortedExposedForKeyDate(receivedAt.minusDays(1), null, now, now);
 
     assertFalse(sortedExposedForDay.isEmpty());
 
     gaenDataService.cleanDB(Duration.ofDays(21));
     sortedExposedForDay =
-        gaenDataService.getSortedExposedForKeyDate(receivedAt.minusDays(1), null, now);
+        gaenDataService.getSortedExposedForKeyDate(receivedAt.minusDays(1), null, now, now);
 
     assertTrue(sortedExposedForDay.isEmpty());
   }
@@ -180,7 +180,7 @@ public class PostgresGaenDataServiceTest {
 
     var returnedKeys =
         gaenDataService.getSortedExposedForKeyDate(
-            UTCInstant.today().minus(Duration.ofDays(1)), null, publishedUntil);
+            UTCInstant.today().minus(Duration.ofDays(1)), null, publishedUntil, now);
 
     assertEquals(keys.size(), returnedKeys.size());
     assertEquals(keys.get(0).getKeyData(), returnedKeys.get(0).getKeyData());
@@ -198,7 +198,7 @@ public class PostgresGaenDataServiceTest {
 
     var returnedKeys =
         gaenDataService.getSortedExposedForKeyDate(
-            receivedAt.minus(Duration.ofDays(2)), null, batchTime);
+            receivedAt.minus(Duration.ofDays(2)), null, batchTime, now);
 
     assertEquals(1, returnedKeys.size());
     GaenKey actual = returnedKeys.get(0);
@@ -206,12 +206,12 @@ public class PostgresGaenDataServiceTest {
 
     int maxExposedIdForBatchReleaseTime =
         gaenDataService.getMaxExposedIdForKeyDate(
-            receivedAt.minus(Duration.ofDays(2)), null, batchTime);
+            receivedAt.minus(Duration.ofDays(2)), null, batchTime, now);
     assertEquals(100, maxExposedIdForBatchReleaseTime);
 
     returnedKeys =
         gaenDataService.getSortedExposedForKeyDate(
-            receivedAt.minus(Duration.ofDays(2)), batchTime, batchTime.plusHours(2));
+            receivedAt.minus(Duration.ofDays(2)), batchTime, batchTime.plusHours(2), now);
     assertEquals(0, returnedKeys.size());
   }
 

--- a/dpppt-backend-sdk/dpppt-backend-sdk-data/src/test/java/org/dpppt/backend/sdk/data/gaen/PostgresGaenDataServiceTest.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-data/src/test/java/org/dpppt/backend/sdk/data/gaen/PostgresGaenDataServiceTest.java
@@ -71,32 +71,31 @@ public class PostgresGaenDataServiceTest {
   }
 
   @Test
-  public void testFakeKeyContainsKeysForLast21Days() {
+  public void testFakeKeyContainsKeysForLast21Days() throws Exception {
     Clock threeOClock = Clock.fixed(UTCInstant.today().plusHours(4).getInstant(), ZoneOffset.UTC);
-    UTCInstant.setClock(threeOClock);
-    var today = UTCInstant.today();
-    var now = UTCInstant.now();
-    var noKeyAtThisDate = today.minusDays(22);
-    var keysUntilToday = today.minusDays(21);
+    try (var lockedClock = UTCInstant.setClock(threeOClock)) {
+      var today = UTCInstant.today();
+      var now = UTCInstant.now();
+      var noKeyAtThisDate = today.minusDays(22);
+      var keysUntilToday = today.minusDays(21);
 
-    var keys = new ArrayList<GaenKey>();
-    var emptyList = fakeKeyService.fillUpKeys(keys, null, noKeyAtThisDate, now);
-    assertEquals(0, emptyList.size());
-    do {
+      var keys = new ArrayList<GaenKey>();
+      var emptyList = fakeKeyService.fillUpKeys(keys, null, noKeyAtThisDate, now);
+      assertEquals(0, emptyList.size());
+      do {
+        keys.clear();
+        var list = fakeKeyService.fillUpKeys(keys, null, keysUntilToday, now);
+
+        assertEquals(10, list.size());
+        list = fakeKeyService.fillUpKeys(keys, UTCInstant.now().plusHours(3), keysUntilToday, now);
+        assertEquals(10, list.size());
+        keysUntilToday = keysUntilToday.plusDays(1);
+      } while (keysUntilToday.isBeforeDateOf(today));
+
       keys.clear();
-      var list = fakeKeyService.fillUpKeys(keys, null, keysUntilToday, now);
-
-      assertEquals(10, list.size());
-      list = fakeKeyService.fillUpKeys(keys, UTCInstant.now().plusHours(3), keysUntilToday, now);
-      assertEquals(10, list.size());
-      keysUntilToday = keysUntilToday.plusDays(1);
-    } while (keysUntilToday.isBeforeDateOf(today));
-
-    keys.clear();
-    emptyList = fakeKeyService.fillUpKeys(keys, null, noKeyAtThisDate, now);
-    assertEquals(0, emptyList.size());
-
-    UTCInstant.resetClock();
+      emptyList = fakeKeyService.fillUpKeys(keys, null, noKeyAtThisDate, now);
+      assertEquals(0, emptyList.size());
+    }
   }
 
   @Test
@@ -120,27 +119,28 @@ public class PostgresGaenDataServiceTest {
     Clock nextDay =
         Clock.fixed(localDateNow.plusDays(2).plusMinutes(2).getInstant(), ZoneOffset.UTC);
 
-    UTCInstant.setClock(twoMinutesToMidnight);
-
-    boolean actual =
-        redeemDataService.checkAndInsertPublishUUID("bc77d983-2359-48e8-835a-de673fe53ccb");
-    assertTrue(actual);
+    try (var lockedClock = UTCInstant.setClock(twoMinutesToMidnight)) {
+      boolean actual =
+          redeemDataService.checkAndInsertPublishUUID("bc77d983-2359-48e8-835a-de673fe53ccb");
+      assertTrue(actual);
+    }
 
     // token is still valid for 1 minute
-    UTCInstant.setClock(twoMinutesAfterMidnight);
+    try (var lockedClock = UTCInstant.setClock(twoMinutesAfterMidnight)) {
+      redeemDataService.cleanDB(Duration.ofDays(1));
 
-    redeemDataService.cleanDB(Duration.ofDays(1));
+      boolean actual =
+          redeemDataService.checkAndInsertPublishUUID("bc77d983-2359-48e8-835a-de673fe53ccb");
+      assertFalse(actual);
+    }
 
-    actual = redeemDataService.checkAndInsertPublishUUID("bc77d983-2359-48e8-835a-de673fe53ccb");
-    assertFalse(actual);
+    try (var lockedClock = UTCInstant.setClock(nextDay)) {
+      redeemDataService.cleanDB(Duration.ofDays(1));
 
-    UTCInstant.setClock(nextDay);
-
-    redeemDataService.cleanDB(Duration.ofDays(1));
-
-    actual = redeemDataService.checkAndInsertPublishUUID("bc77d983-2359-48e8-835a-de673fe53ccb");
-    assertTrue(actual);
-    UTCInstant.resetClock();
+      boolean actual =
+          redeemDataService.checkAndInsertPublishUUID("bc77d983-2359-48e8-835a-de673fe53ccb");
+      assertTrue(actual);
+    }
   }
 
   @Test

--- a/dpppt-backend-sdk/dpppt-backend-sdk-data/src/test/java/org/dpppt/backend/sdk/data/gaen/PostgresGaenDataServiceTest.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-data/src/test/java/org/dpppt/backend/sdk/data/gaen/PostgresGaenDataServiceTest.java
@@ -72,6 +72,8 @@ public class PostgresGaenDataServiceTest {
 
   @Test
   public void testFakeKeyContainsKeysForLast21Days() {
+    Clock threeOClock = Clock.fixed(UTCInstant.today().plusHours(4).getInstant(), ZoneOffset.UTC);
+    UTCInstant.setClock(threeOClock);
     var today = UTCInstant.today();
     var now = UTCInstant.now();
     var noKeyAtThisDate = today.minusDays(22);
@@ -93,6 +95,8 @@ public class PostgresGaenDataServiceTest {
     keys.clear();
     emptyList = fakeKeyService.fillUpKeys(keys, null, noKeyAtThisDate, now);
     assertEquals(0, emptyList.size());
+
+    UTCInstant.resetClock();
   }
 
   @Test

--- a/dpppt-backend-sdk/dpppt-backend-sdk-data/src/test/java/org/dpppt/backend/sdk/data/gaen/PostgresGaenDataServiceTest.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-data/src/test/java/org/dpppt/backend/sdk/data/gaen/PostgresGaenDataServiceTest.java
@@ -208,11 +208,6 @@ public class PostgresGaenDataServiceTest {
     GaenKey actual = returnedKeys.get(0);
     assertEquals(actual.getKeyData(), key);
 
-    int maxExposedIdForBatchReleaseTime =
-        gaenDataService.getMaxExposedIdForKeyDate(
-            receivedAt.minus(Duration.ofDays(2)), null, batchTime, now);
-    assertEquals(100, maxExposedIdForBatchReleaseTime);
-
     returnedKeys =
         gaenDataService.getSortedExposedForKeyDate(
             receivedAt.minus(Duration.ofDays(2)), batchTime, batchTime.plusHours(2), now);

--- a/dpppt-backend-sdk/dpppt-backend-sdk-model/src/main/java/org/dpppt/backend/sdk/utils/UTCInstant.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-model/src/main/java/org/dpppt/backend/sdk/utils/UTCInstant.java
@@ -55,7 +55,28 @@ public class UTCInstant implements Closeable {
     this.timestamp = offsetDateTime.toInstant().toEpochMilli();
   }
 
-  // TODO: make protected and subclass for use in tests
+  /**
+   * <b>This function should only be used in test classes</b> ~~or if you absolutely sure that you
+   * need it~~. <br>
+   * It changes the static field clock, which means now() and today() return values based on this
+   * new clock. The method returns null if the clock is different to systemUTC, meaning it already
+   * has been changed elsewhere.
+   *
+   * <p>We use https://github.com/DP-3T/dp3t-sdk-backend/issues/246 to track improvements to this
+   * method, including but not limited to
+   *
+   * <ul>
+   *   <li>Using now(Clock clock) and today(Clock clock) with a injected Clock into controllers.
+   *   <li>Using beans
+   * </ul>
+   *
+   * <br>
+   *
+   * @param clock the clock, which should be used for all further invocations of now() or today()
+   * @return Returns a now object, which can be used for the try-with statement. This is the
+   *     recommended way of using it, since it guarantees that resetClock() is called as soon as the
+   *     instance goes out of scope
+   */
   public static UTCInstant setClock(Clock clock) {
     if (currentClock != Clock.systemUTC()) {
       return null;

--- a/dpppt-backend-sdk/dpppt-backend-sdk-model/src/main/java/org/dpppt/backend/sdk/utils/UTCInstant.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-model/src/main/java/org/dpppt/backend/sdk/utils/UTCInstant.java
@@ -1,5 +1,7 @@
 package org.dpppt.backend.sdk.utils;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -21,7 +23,7 @@ import org.dpppt.backend.sdk.model.gaen.GaenUnit;
  * <p>IMPORTANT: `Local*` classes do not carry any timezone informations. As such, all comparisons
  * are made regarding 'UTC'
  */
-public class UTCInstant {
+public class UTCInstant implements Closeable {
   private final long timestamp;
   private static Clock currentClock = Clock.systemUTC();
 
@@ -54,8 +56,12 @@ public class UTCInstant {
   }
 
   // TODO: make protected and subclass for use in tests
-  public static void setClock(Clock clock) {
+  public static UTCInstant setClock(Clock clock) {
+    if (currentClock != Clock.systemUTC()) {
+      return null;
+    }
     currentClock = clock;
+    return UTCInstant.now();
   }
 
   public static void resetClock() {
@@ -272,5 +278,10 @@ public class UTCInstant {
     } else {
       Thread.sleep(timeFillUp.toMillis());
     }
+  }
+
+  @Override
+  public void close() throws IOException {
+    UTCInstant.resetClock();
   }
 }

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/config/WSBaseConfig.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/config/WSBaseConfig.java
@@ -143,6 +143,9 @@ public abstract class WSBaseConfig implements SchedulingConfigurer, WebMvcConfig
   @Value("${ws.app.gaen.algorithm:1.2.840.10045.4.3.2}")
   String gaenAlgorithm;
 
+  @Value("${ws.app.gaen.timeskew:PT2h}")
+  Duration timeSkew;
+
   @Autowired(required = false)
   ValidateRequest requestValidator;
 
@@ -185,7 +188,7 @@ public abstract class WSBaseConfig implements SchedulingConfigurer, WebMvcConfig
       flyWay.migrate();
       GAENDataService fakeGaenService =
           new JDBCGAENDataServiceImpl(
-              "hsql", fakeDataSource, Duration.ofMillis(releaseBucketDuration));
+              "hsql", fakeDataSource, Duration.ofMillis(releaseBucketDuration), timeSkew);
       return new FakeKeyService(
           fakeGaenService,
           Integer.valueOf(randomkeyamount),
@@ -329,7 +332,7 @@ public abstract class WSBaseConfig implements SchedulingConfigurer, WebMvcConfig
   @Bean
   public GAENDataService gaenDataService() {
     return new JDBCGAENDataServiceImpl(
-        getDbType(), dataSource(), Duration.ofMillis(releaseBucketDuration));
+        getDbType(), dataSource(), Duration.ofMillis(releaseBucketDuration), timeSkew);
   }
 
   @Bean

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/GaenController.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/GaenController.java
@@ -283,8 +283,9 @@ public class GaenController {
 
     var exposedKeys =
         dataService.getSortedExposedForKeyDate(
-            keyDateInstant, publishedAfterInstant, publishedUntil);
-    exposedKeys = fakeKeyService.fillUpKeys(exposedKeys, publishedAfterInstant, keyDateInstant);
+            keyDateInstant, publishedAfterInstant, publishedUntil, now);
+    exposedKeys =
+        fakeKeyService.fillUpKeys(exposedKeys, publishedAfterInstant, keyDateInstant, now);
     if (exposedKeys.isEmpty()) {
       return ResponseEntity.noContent()
           .cacheControl(CacheControl.maxAge(exposedListCacheControl))

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/controller/GaenControllerTest.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/controller/GaenControllerTest.java
@@ -1237,52 +1237,53 @@ public class GaenControllerTest extends BaseControllerTest {
   @Test
   @Transactional
   public void zipContainsFiles() throws Exception {
-    var now = UTCInstant.now();
-    var clock = Clock.offset(Clock.systemUTC(), now.getDuration(now.atStartOfDay().plusHours(12)));
-    UTCInstant.setClock(clock);
-    now = UTCInstant.now();
-    var midnight = now.atStartOfDay();
+    var outerNow = UTCInstant.now();
+    var clock =
+        Clock.offset(
+            Clock.systemUTC(), outerNow.getDuration(outerNow.atStartOfDay().plusHours(12)));
+    try (var now = UTCInstant.setClock(clock)) {
+      var midnight = now.atStartOfDay();
 
-    // Insert two times 5 keys per day for the last 14 days. the second batch has a
-    // different 'received at' timestamp. (+12 hours compared to the first)
-    insertNKeysPerDay(midnight, 14, 5, midnight.minusDays(1), false);
-    insertNKeysPerDay(midnight, 14, 5, midnight.minusHours(12), false);
+      // Insert two times 5 keys per day for the last 14 days. the second batch has a
+      // different 'received at' timestamp. (+12 hours compared to the first)
+      insertNKeysPerDay(midnight, 14, 5, midnight.minusDays(1), false);
+      insertNKeysPerDay(midnight, 14, 5, midnight.minusHours(12), false);
 
-    // request the keys with key date 8 days ago. no publish until.
-    MockHttpServletResponse response =
-        mockMvc
-            .perform(
-                get("/v1/gaen/exposed/" + midnight.minusDays(8).getTimestamp())
-                    .header("User-Agent", "MockMVC"))
-            .andExpect(status().is2xxSuccessful())
-            .andReturn()
-            .getResponse();
+      // request the keys with key date 8 days ago. no publish until.
+      MockHttpServletResponse response =
+          mockMvc
+              .perform(
+                  get("/v1/gaen/exposed/" + midnight.minusDays(8).getTimestamp())
+                      .header("User-Agent", "MockMVC"))
+              .andExpect(status().is2xxSuccessful())
+              .andReturn()
+              .getResponse();
 
-    Long publishedUntil = Long.parseLong(response.getHeader("X-PUBLISHED-UNTIL"));
-    assertTrue(publishedUntil < now.getTimestamp(), "Published until must be in the past");
+      Long publishedUntil = Long.parseLong(response.getHeader("X-PUBLISHED-UNTIL"));
+      assertTrue(publishedUntil < now.getTimestamp(), "Published until must be in the past");
 
-    // must contain 20 keys: 5 from the first insert, 5 from the second insert and
-    // 10 random keys
-    verifyZipResponse(response, 20, 144);
+      // must contain 20 keys: 5 from the first insert, 5 from the second insert and
+      // 10 random keys
+      verifyZipResponse(response, 20, 144);
 
-    // request again the keys with date date 8 days ago. with publish until, so that
-    // we only get the second batch.
-    var bucketAfterSecondRelease = midnight.minusHours(12);
+      // request again the keys with date date 8 days ago. with publish until, so that
+      // we only get the second batch.
+      var bucketAfterSecondRelease = midnight.minusHours(12);
 
-    MockHttpServletResponse responseWithPublishedAfter =
-        mockMvc
-            .perform(
-                get("/v1/gaen/exposed/" + midnight.minusDays(8).getTimestamp())
-                    .header("User-Agent", "MockMVC")
-                    .param(
-                        "publishedafter", Long.toString(bucketAfterSecondRelease.getTimestamp())))
-            .andExpect(status().is2xxSuccessful())
-            .andReturn()
-            .getResponse();
+      MockHttpServletResponse responseWithPublishedAfter =
+          mockMvc
+              .perform(
+                  get("/v1/gaen/exposed/" + midnight.minusDays(8).getTimestamp())
+                      .header("User-Agent", "MockMVC")
+                      .param(
+                          "publishedafter", Long.toString(bucketAfterSecondRelease.getTimestamp())))
+              .andExpect(status().is2xxSuccessful())
+              .andReturn()
+              .getResponse();
 
-    // must contain 15 keys: 5 from the second insert and 10 random keys
-    verifyZipResponse(responseWithPublishedAfter, 15, 144);
-    UTCInstant.resetClock();
+      // must contain 15 keys: 5 from the second insert and 10 random keys
+      verifyZipResponse(responseWithPublishedAfter, 15, 144);
+    }
   }
 
   @Test
@@ -1433,17 +1434,17 @@ public class GaenControllerTest extends BaseControllerTest {
     Clock fourAMTomorrow =
         Clock.fixed(UTCInstant.today().plusDays(1).plusHours(4).getInstant(), ZoneOffset.UTC);
 
-    UTCInstant.setClock(fourAMTomorrow);
-    response =
-        mockMvc
-            .perform(
-                get("/v1/gaen/exposed/" + tooEarlyInstant.getTimestamp())
-                    .header("User-Agent", androidUserAgent))
-            .andExpect(status().isOk())
-            .andReturn()
-            .getResponse();
-    verifyZipResponse(response, 1, 144);
-    UTCInstant.resetClock();
+    try (var lock = UTCInstant.setClock(fourAMTomorrow)) {
+      response =
+          mockMvc
+              .perform(
+                  get("/v1/gaen/exposed/" + tooEarlyInstant.getTimestamp())
+                      .header("User-Agent", androidUserAgent))
+              .andExpect(status().isOk())
+              .andReturn()
+              .getResponse();
+      verifyZipResponse(response, 1, 144);
+    }
   }
 
   /** Verifies a zip in zip response, that each inner zip is again valid. */

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/controller/GaenControllerTest.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/controller/GaenControllerTest.java
@@ -1418,24 +1418,26 @@ public class GaenControllerTest extends BaseControllerTest {
                     .content(json(exposeeRequest)))
             .andExpect(request().asyncStarted())
             .andReturn();
+    mockMvc.perform(asyncDispatch(responseAsync)).andExpect(status().isOk());
 
-    Clock tomorrow =
-        Clock.fixed(UTCInstant.today().plusDays(1).plusHours(4).getInstant(), ZoneOffset.UTC);
-
+    var tooEarlyInstant = UTCInstant.today();
     MockHttpServletResponse response =
         mockMvc
             .perform(
-                get("/v1/gaen/exposed/" + UTCInstant.today().getTimestamp())
+                get("/v1/gaen/exposed/" + tooEarlyInstant.getTimestamp())
                     .header("User-Agent", androidUserAgent))
             .andExpect(status().is(204))
             .andReturn()
             .getResponse();
 
-    UTCInstant.setClock(tomorrow);
+    Clock fourAMTomorrow =
+        Clock.fixed(UTCInstant.today().plusDays(1).plusHours(4).getInstant(), ZoneOffset.UTC);
+
+    UTCInstant.setClock(fourAMTomorrow);
     response =
         mockMvc
             .perform(
-                get("/v1/gaen/exposed/" + UTCInstant.today().minusDays(1).getTimestamp())
+                get("/v1/gaen/exposed/" + tooEarlyInstant.getTimestamp())
                     .header("User-Agent", androidUserAgent))
             .andExpect(status().isOk())
             .andReturn()

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/controller/GaenControllerTest.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/controller/GaenControllerTest.java
@@ -135,19 +135,19 @@ public class GaenControllerTest extends BaseControllerTest {
     var requestList = new GaenRequest();
     var gaenKey1 = new GaenKey();
     gaenKey1.setRollingStartNumber((int) now.atStartOfDay().minusDays(1).get10MinutesSince1970());
-    gaenKey1.setKeyData(Base64.getEncoder().encodeToString("testKey32Bytes01".getBytes("UTF-8")));
+    gaenKey1.setKeyData(Base64.getEncoder().encodeToString("testKey32Bytesa1".getBytes("UTF-8")));
     gaenKey1.setRollingPeriod(144);
     gaenKey1.setFake(0);
     gaenKey1.setTransmissionRiskLevel(0);
     var gaenKey2 = new GaenKey();
     gaenKey2.setRollingStartNumber((int) now.atStartOfDay().minusDays(1).get10MinutesSince1970());
-    gaenKey2.setKeyData(Base64.getEncoder().encodeToString("testKey32Bytes02".getBytes("UTF-8")));
+    gaenKey2.setKeyData(Base64.getEncoder().encodeToString("testKey32Bytesb2".getBytes("UTF-8")));
     gaenKey2.setRollingPeriod(144);
     gaenKey2.setFake(0);
     gaenKey2.setTransmissionRiskLevel(0);
     var gaenKey3 = new GaenKey();
     gaenKey3.setRollingStartNumber((int) now.atStartOfDay().get10MinutesSince1970());
-    gaenKey3.setKeyData(Base64.getEncoder().encodeToString("testKey32Bytes03".getBytes("UTF-8")));
+    gaenKey3.setKeyData(Base64.getEncoder().encodeToString("testKey32Bytesc3".getBytes("UTF-8")));
     gaenKey3.setRollingPeriod(144);
     gaenKey3.setFake(0);
     gaenKey3.setTransmissionRiskLevel(0);
@@ -158,7 +158,7 @@ public class GaenControllerTest extends BaseControllerTest {
     for (int i = 0; i < n - 3; i++) {
       var tmpKey = new GaenKey();
       tmpKey.setRollingStartNumber((int) now.atStartOfDay().get10MinutesSince1970());
-      tmpKey.setKeyData(Base64.getEncoder().encodeToString("testKey32Bytes--".getBytes("UTF-8")));
+      tmpKey.setKeyData(Base64.getEncoder().encodeToString("testKey32Bytesaa".getBytes("UTF-8")));
       tmpKey.setRollingPeriod(144);
       tmpKey.setFake(1);
       tmpKey.setTransmissionRiskLevel(0);
@@ -217,8 +217,8 @@ public class GaenControllerTest extends BaseControllerTest {
             now);
     assertEquals(0, result.size());
 
-    // third key should be released tomorrow
-    var tomorrow2AM = now.atStartOfDay().plusDays(1).plusHours(2).plusSeconds(1);
+    // third key should be released tomorrow (at four)
+    var tomorrow2AM = now.atStartOfDay().plusDays(1).plusHours(4).plusSeconds(1);
     result =
         gaenDataService.getSortedExposedForKeyDate(
             now.atStartOfDay(),

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/insertmanager/MockDataSource.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/insertmanager/MockDataSource.java
@@ -20,13 +20,6 @@ public class MockDataSource implements GAENDataService {
   }
 
   @Override
-  public int getMaxExposedIdForKeyDate(
-      UTCInstant keyDate, UTCInstant publishedAfter, UTCInstant publishedUntil, UTCInstant now) {
-    // TODO Auto-generated method stub
-    return 0;
-  }
-
-  @Override
   public List<GaenKey> getSortedExposedForKeyDate(
       UTCInstant keyDate, UTCInstant publishedAfter, UTCInstant publishedUntil, UTCInstant now) {
     // TODO Auto-generated method stub

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/insertmanager/MockDataSource.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/insertmanager/MockDataSource.java
@@ -21,14 +21,14 @@ public class MockDataSource implements GAENDataService {
 
   @Override
   public int getMaxExposedIdForKeyDate(
-      UTCInstant keyDate, UTCInstant publishedAfter, UTCInstant publishedUntil) {
+      UTCInstant keyDate, UTCInstant publishedAfter, UTCInstant publishedUntil, UTCInstant now) {
     // TODO Auto-generated method stub
     return 0;
   }
 
   @Override
   public List<GaenKey> getSortedExposedForKeyDate(
-      UTCInstant keyDate, UTCInstant publishedAfter, UTCInstant publishedUntil) {
+      UTCInstant keyDate, UTCInstant publishedAfter, UTCInstant publishedUntil, UTCInstant now) {
     // TODO Auto-generated method stub
     return null;
   }


### PR DESCRIPTION
With the new pipeline we try to sanitise input on insert. Since due to various possible issues (and for easier debugging) we could insert keys with validity exceeding the current bucket (e.g. a key submitted today with todays keydate and rolling period 144), we additionally filter for such keys on release. Adding the rules for filtering into the SQL query should decrease the risk of accidentally releasing keys too early (e.g. bugs during insert, manipulating JWTs or other yet unknown problems).

To minmise merge conflicts, this PR depends on https://github.com/DP-3T/dp3t-sdk-backend/pull/213

Linted and rebased - original is at f881f566b53a335f56661041b22c3872e145a8bd
Moved non-related changes to #234 - original is at baa1f96fe8a69f6aada110920ac3283f707e4a85
