### PR TITLE
Add roundTo(BucketStart|NextBucket) to UTCInstant

### DIFF
--- a/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/gaen/FakeKeyService.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/gaen/FakeKeyService.java
@@ -63,18 +63,19 @@ public class FakeKeyService {
     this.dataService.cleanDB(Duration.ofDays(0));
   }
 
-  public List<GaenKey> fillUpKeys(List<GaenKey> keys, Long publishedafter, Long keyDate) {
+  public List<GaenKey> fillUpKeys(
+      List<GaenKey> keys, UTCInstant publishedafter, UTCInstant keyDate) {
     if (!isEnabled) {
       return keys;
     }
     var today = UTCInstant.today();
-    var keyLocalDate = UTCInstant.ofEpochMillis(keyDate).atStartOfDay();
+    var keyLocalDate = keyDate.atStartOfDay();
     if (today.hasSameDateAs(keyLocalDate)) {
       return keys;
     }
     var fakeKeys =
         this.dataService.getSortedExposedForKeyDate(
-            keyDate, publishedafter, UTCInstant.today().plusDays(1).getTimestamp());
+            keyDate, publishedafter, UTCInstant.today().plusDays(1));
 
     keys.addAll(fakeKeys);
     return keys;

--- a/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/gaen/GAENDataService.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/gaen/GAENDataService.java
@@ -21,6 +21,7 @@ public interface GAENDataService {
    * Upserts (Update or Inserts) the given list of exposed keys
    *
    * @param keys the list of exposed keys to upsert
+   * @param now time of the request
    */
   void upsertExposees(List<GaenKey> keys, UTCInstant now);
 
@@ -31,6 +32,7 @@ public interface GAENDataService {
    * @param keys the list of exposed keys to upsert
    * @param delayedReceivedAt the timestamp to use for the delayed release (if null use now rounded
    *     to next bucket)
+   * @param now time of the request
    */
   void upsertExposeesDelayed(List<GaenKey> keys, UTCInstant delayedReceivedAt, UTCInstant now);
 
@@ -42,7 +44,8 @@ public interface GAENDataService {
    * @param publishedUntil in milliseconds since Unix epoch
    * @return the maximum id of the stored exposed entries for the given batch
    */
-  int getMaxExposedIdForKeyDate(Long keyDate, Long publishedAfter, Long publishedUntil);
+  int getMaxExposedIdForKeyDate(
+      UTCInstant keyDate, UTCInstant publishedAfter, UTCInstant publishedUntil);
 
   /**
    * Returns all exposeed keys for the given batch.
@@ -52,7 +55,8 @@ public interface GAENDataService {
    * @param publishedUntil in milliseconds since Unix epoch
    * @return all exposeed keys for the given batch
    */
-  List<GaenKey> getSortedExposedForKeyDate(Long keyDate, Long publishedAfter, Long publishedUntil);
+  List<GaenKey> getSortedExposedForKeyDate(
+      UTCInstant keyDate, UTCInstant publishedAfter, UTCInstant publishedUntil);
 
   /**
    * deletes entries older than retentionperiod

--- a/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/gaen/JDBCGAENDataServiceImpl.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/gaen/JDBCGAENDataServiceImpl.java
@@ -69,17 +69,15 @@ public class JDBCGAENDataServiceImpl implements GAENDataService {
     // Calculate the `receivedAt` just at the end of the current releaseBucket.
     var receivedAt =
         delayedReceivedAt == null
-            ? (now.getTimestamp() / releaseBucketDuration.toMillis() + 1)
-                    * releaseBucketDuration.toMillis()
-                - 1
-            : delayedReceivedAt.getTimestamp();
+            ? now.roundToNextBucket(releaseBucketDuration).minus(Duration.ofMillis(1))
+            : delayedReceivedAt;
     for (var gaenKey : gaenKeys) {
       MapSqlParameterSource params = new MapSqlParameterSource();
       params.addValue("key", gaenKey.getKeyData());
       params.addValue("rolling_start_number", gaenKey.getRollingStartNumber());
       params.addValue("rolling_period", gaenKey.getRollingPeriod());
       params.addValue("transmission_risk_level", gaenKey.getTransmissionRiskLevel());
-      params.addValue("received_at", UTCInstant.ofEpochMillis(receivedAt).getDate());
+      params.addValue("received_at", receivedAt.getDate());
 
       parameterList.add(params);
     }
@@ -88,14 +86,12 @@ public class JDBCGAENDataServiceImpl implements GAENDataService {
 
   @Override
   @Transactional(readOnly = true)
-  public int getMaxExposedIdForKeyDate(Long keyDate, Long publishedAfter, Long publishedUntil) {
+  public int getMaxExposedIdForKeyDate(
+      UTCInstant keyDate, UTCInstant publishedAfter, UTCInstant publishedUntil) {
     MapSqlParameterSource params = new MapSqlParameterSource();
-    params.addValue(
-        "rollingPeriodStartNumberStart", UTCInstant.ofEpochMillis(keyDate).get10MinutesSince1970());
-    params.addValue(
-        "rollingPeriodStartNumberEnd",
-        UTCInstant.ofEpochMillis(keyDate).plusDays(1).get10MinutesSince1970());
-    params.addValue("publishedUntil", UTCInstant.ofEpochMillis(publishedUntil).getDate());
+    params.addValue("rollingPeriodStartNumberStart", keyDate.get10MinutesSince1970());
+    params.addValue("rollingPeriodStartNumberEnd", keyDate.plusDays(1).get10MinutesSince1970());
+    params.addValue("publishedUntil", publishedUntil.getDate());
 
     String sql =
         "select max(pk_exposed_id) from t_gaen_exposed where"
@@ -104,7 +100,7 @@ public class JDBCGAENDataServiceImpl implements GAENDataService {
             + " and received_at < :publishedUntil";
 
     if (publishedAfter != null) {
-      params.addValue("publishedAfter", UTCInstant.ofEpochMillis(publishedAfter).getDate());
+      params.addValue("publishedAfter", publishedAfter.getDate());
       sql += " and received_at >= :publishedAfter";
     }
 
@@ -119,14 +115,11 @@ public class JDBCGAENDataServiceImpl implements GAENDataService {
   @Override
   @Transactional(readOnly = true)
   public List<GaenKey> getSortedExposedForKeyDate(
-      Long keyDate, Long publishedAfter, Long publishedUntil) {
+      UTCInstant keyDate, UTCInstant publishedAfter, UTCInstant publishedUntil) {
     MapSqlParameterSource params = new MapSqlParameterSource();
-    params.addValue(
-        "rollingPeriodStartNumberStart", UTCInstant.ofEpochMillis(keyDate).get10MinutesSince1970());
-    params.addValue(
-        "rollingPeriodStartNumberEnd",
-        UTCInstant.ofEpochMillis(keyDate).plusDays(1).get10MinutesSince1970());
-    params.addValue("publishedUntil", UTCInstant.ofEpochMillis(publishedUntil).getDate());
+    params.addValue("rollingPeriodStartNumberStart", keyDate.get10MinutesSince1970());
+    params.addValue("rollingPeriodStartNumberEnd", keyDate.plusDays(1).get10MinutesSince1970());
+    params.addValue("publishedUntil", publishedUntil.getDate());
 
     String sql =
         "select pk_exposed_id, key, rolling_start_number, rolling_period, transmission_risk_level"
@@ -135,7 +128,7 @@ public class JDBCGAENDataServiceImpl implements GAENDataService {
             + " :publishedUntil";
 
     if (publishedAfter != null) {
-      params.addValue("publishedAfter", UTCInstant.ofEpochMillis(publishedAfter).getDate());
+      params.addValue("publishedAfter", publishedAfter.getDate());
       sql += " and received_at >= :publishedAfter";
     }
 

--- a/dpppt-backend-sdk/dpppt-backend-sdk-data/src/test/java/org/dpppt/backend/sdk/data/gaen/GaenDataServiceTest.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-data/src/test/java/org/dpppt/backend/sdk/data/gaen/GaenDataServiceTest.java
@@ -52,17 +52,16 @@ public class GaenDataServiceTest {
     tmpKey2.setFake(0);
     tmpKey2.setTransmissionRiskLevel(0);
     List<GaenKey> keys = List.of(tmpKey, tmpKey2);
-    var utcNow = UTCInstant.now();
-    gaenDataService.upsertExposees(keys, utcNow);
+    var now = UTCInstant.now();
+    gaenDataService.upsertExposees(keys, now);
 
-    long now = utcNow.getTimestamp();
     // calculate exposed until bucket, but get bucket in the future, as keys have
     // been inserted with timestamp now.
-    long publishedUntil = now - (now % BUCKET_LENGTH.toMillis()) + BUCKET_LENGTH.toMillis();
+    UTCInstant publishedUntil = now.roundToNextBucket(BUCKET_LENGTH);
 
     var returnedKeys =
         gaenDataService.getSortedExposedForKeyDate(
-            UTCInstant.today().minusDays(1).getTimestamp(), null, publishedUntil);
+            UTCInstant.today().minusDays(1), null, publishedUntil);
 
     assertEquals(keys.size(), returnedKeys.size());
     assertEquals(keys.get(1).getKeyData(), returnedKeys.get(0).getKeyData());

--- a/dpppt-backend-sdk/dpppt-backend-sdk-model/src/main/java/org/dpppt/backend/sdk/utils/UTCInstant.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-model/src/main/java/org/dpppt/backend/sdk/utils/UTCInstant.java
@@ -71,8 +71,8 @@ public class UTCInstant {
     return new UTCInstant(amount, unit);
   }
 
-  public static UTCInstant ofEpochMillis(long epochMillis) {
-    return new UTCInstant(epochMillis);
+  public static UTCInstant ofEpochMillis(Long epochMillis) {
+    return new UTCInstant(epochMillis == null ? 0 : epochMillis);
   }
 
   public static UTCInstant parseDate(String dateString) {
@@ -120,6 +120,20 @@ public class UTCInstant {
 
   public LocalTime getLocalTime() {
     return getLocalDateTime().toLocalTime();
+  }
+
+  public UTCInstant roundToPreviousBucket(Duration releaseBucketDuration) {
+    var roundedTimestamp =
+        (long) Math.floor(this.timestamp / releaseBucketDuration.toMillis())
+            * releaseBucketDuration.toMillis();
+    return new UTCInstant(roundedTimestamp);
+  }
+
+  public UTCInstant roundToNextBucket(Duration releaseBucketDuration) {
+    var roundedTimestamp =
+        ((long) Math.floor(this.timestamp / releaseBucketDuration.toMillis()) + 1)
+            * releaseBucketDuration.toMillis();
+    return new UTCInstant(roundedTimestamp);
   }
 
   public UTCInstant plus(Duration duration) {

--- a/dpppt-backend-sdk/dpppt-backend-sdk-model/src/main/java/org/dpppt/backend/sdk/utils/UTCInstant.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-model/src/main/java/org/dpppt/backend/sdk/utils/UTCInstant.java
@@ -128,7 +128,7 @@ public class UTCInstant {
    *     start of a bucket, it will be returned as-is.
    */
   public UTCInstant roundToBucketStart(Duration releaseBucketDuration) {
-    var rounding = releaseBucketDuration.toMillis();
+    long rounding = releaseBucketDuration.toMillis();
     return new UTCInstant((this.timestamp / rounding) * rounding);
   }
 
@@ -138,7 +138,7 @@ public class UTCInstant {
    *     of a bucket, the next bucket will be returned.
    */
   public UTCInstant roundToNextBucket(Duration releaseBucketDuration) {
-    var rounding = releaseBucketDuration.toMillis();
+    long rounding = releaseBucketDuration.toMillis();
     return new UTCInstant(((this.timestamp / rounding) + 1) * rounding);
   }
 

--- a/dpppt-backend-sdk/dpppt-backend-sdk-model/src/main/java/org/dpppt/backend/sdk/utils/UTCInstant.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-model/src/main/java/org/dpppt/backend/sdk/utils/UTCInstant.java
@@ -122,18 +122,24 @@ public class UTCInstant {
     return getLocalDateTime().toLocalTime();
   }
 
-  public UTCInstant roundToPreviousBucket(Duration releaseBucketDuration) {
-    var roundedTimestamp =
-        (long) Math.floor(this.timestamp / releaseBucketDuration.toMillis())
-            * releaseBucketDuration.toMillis();
-    return new UTCInstant(roundedTimestamp);
+  /**
+   * @param releaseBucketDuration
+   * @return the start of the bucket this UTCInstant is in. If the UTCInstant is already at the
+   *     start of a bucket, it will be returned as-is.
+   */
+  public UTCInstant roundToBucketStart(Duration releaseBucketDuration) {
+    var rounding = releaseBucketDuration.toMillis();
+    return new UTCInstant((this.timestamp / rounding) * rounding);
   }
 
+  /**
+   * @param releaseBucketDuration
+   * @return the start of the next bucket of this UTCInstant. If the UTCInstant is at the beginning
+   *     of a bucket, the next bucket will be returned.
+   */
   public UTCInstant roundToNextBucket(Duration releaseBucketDuration) {
-    var roundedTimestamp =
-        ((long) Math.floor(this.timestamp / releaseBucketDuration.toMillis()) + 1)
-            * releaseBucketDuration.toMillis();
-    return new UTCInstant(roundedTimestamp);
+    var rounding = releaseBucketDuration.toMillis();
+    return new UTCInstant(((this.timestamp / rounding) + 1) * rounding);
   }
 
   public UTCInstant plus(Duration duration) {
@@ -242,6 +248,10 @@ public class UTCInstant {
 
   public boolean isAfterToday() {
     return this.isAfterDateOf(UTCInstant.now());
+  }
+
+  public boolean equals(UTCInstant o) {
+    return this.timestamp == o.timestamp;
   }
 
   /**

--- a/dpppt-backend-sdk/dpppt-backend-sdk-model/src/test/java/org/dpppt/backend/sdk/utils/UTCInstantTest.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-model/src/test/java/org/dpppt/backend/sdk/utils/UTCInstantTest.java
@@ -22,4 +22,22 @@ class UTCInstantTest {
 
     assertThrows(DurationExpiredException.class, () -> now.normalizeDuration(minimumDuration));
   }
+
+  // Test corner-cases of roundToBucket
+  @Test
+  void roundToBucket() {
+    UTCInstant keyTime = new UTCInstant((100));
+
+    var bucket = Duration.ofMillis(100);
+    assertTrue(keyTime.roundToNextBucket(bucket).equals(new UTCInstant((200))));
+    assertTrue(keyTime.roundToBucketStart(bucket).equals(new UTCInstant((100))));
+
+    bucket = Duration.ofMillis(101);
+    assertTrue(keyTime.roundToNextBucket(bucket).equals(new UTCInstant((101))));
+    assertTrue(keyTime.roundToBucketStart(bucket).equals(new UTCInstant((0))));
+
+    bucket = Duration.ofMillis(99);
+    assertTrue(keyTime.roundToNextBucket(bucket).equals(new UTCInstant((198))));
+    assertTrue(keyTime.roundToBucketStart(bucket).equals(new UTCInstant((99))));
+  }
 }

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/GaenController.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/GaenController.java
@@ -264,26 +264,28 @@ public class GaenController {
       throws BadBatchReleaseTimeException, IOException, InvalidKeyException, SignatureException,
           NoSuchAlgorithmException {
     var now = UTCInstant.now();
+    var publishedAfterInstant = UTCInstant.ofEpochMillis(publishedafter);
+    var keyDateInstant = UTCInstant.ofEpochMillis(keyDate);
+
     if (!validationUtils.isValidKeyDate(UTCInstant.ofEpochMillis(keyDate))) {
       return ResponseEntity.notFound().build();
     }
     if (publishedafter != null
-        && !validationUtils.isValidBatchReleaseTime(
-            UTCInstant.ofEpochMillis(publishedafter), now)) {
+        && !validationUtils.isValidBatchReleaseTime(publishedAfterInstant, now)) {
       return ResponseEntity.notFound().build();
     }
 
     // calculate exposed until bucket
-    long publishedUntil =
-        now.getTimestamp() - (now.getTimestamp() % releaseBucketDuration.toMillis());
+    UTCInstant publishedUntil = now.roundToPreviousBucket(releaseBucketDuration);
 
     var exposedKeys =
-        dataService.getSortedExposedForKeyDate(keyDate, publishedafter, publishedUntil);
-    exposedKeys = fakeKeyService.fillUpKeys(exposedKeys, publishedafter, keyDate);
+        dataService.getSortedExposedForKeyDate(
+            keyDateInstant, publishedAfterInstant, publishedUntil);
+    exposedKeys = fakeKeyService.fillUpKeys(exposedKeys, publishedAfterInstant, keyDateInstant);
     if (exposedKeys.isEmpty()) {
       return ResponseEntity.noContent()
           .cacheControl(CacheControl.maxAge(exposedListCacheControl))
-          .header("X-PUBLISHED-UNTIL", Long.toString(publishedUntil))
+          .header("X-PUBLISHED-UNTIL", Long.toString(publishedUntil.getTimestamp()))
           .build();
     }
 
@@ -291,7 +293,7 @@ public class GaenController {
 
     return ResponseEntity.ok()
         .cacheControl(CacheControl.maxAge(exposedListCacheControl))
-        .header("X-PUBLISHED-UNTIL", Long.toString(publishedUntil))
+        .header("X-PUBLISHED-UNTIL", Long.toString(publishedUntil.getTimestamp()))
         .body(payload.getZip());
   }
 

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/GaenController.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/GaenController.java
@@ -279,7 +279,7 @@ public class GaenController {
     }
 
     // calculate exposed until bucket
-    UTCInstant publishedUntil = now.roundToPreviousBucket(releaseBucketDuration);
+    UTCInstant publishedUntil = now.roundToBucketStart(releaseBucketDuration);
 
     var exposedKeys =
         dataService.getSortedExposedForKeyDate(

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/controller/GaenControllerTest.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/controller/GaenControllerTest.java
@@ -77,9 +77,9 @@ public class GaenControllerTest extends BaseControllerTest {
   @Autowired ProtoSignature signer;
   @Autowired KeyVault keyVault;
   @Autowired GAENDataService gaenDataService;
-  Long releaseBucketDuration = 7200000L;
   private static final String androidUserAgent =
       "ch.admin.bag.dp3t.dev;1.0.7;1595591959493;Android;29";
+  Duration releaseBucketDuration = Duration.ofMillis(7200000L);
 
   private static final Logger logger = LoggerFactory.getLogger(GaenControllerTest.class);
 
@@ -192,9 +192,7 @@ public class GaenControllerTest extends BaseControllerTest {
 
     var result =
         gaenDataService.getSortedExposedForKeyDate(
-            now.atStartOfDay().minusDays(1).getTimestamp(),
-            null,
-            (now.getTimestamp() / releaseBucketDuration + 1) * releaseBucketDuration);
+            now.atStartOfDay().minusDays(1), null, now.roundToNextBucket(releaseBucketDuration));
     assertEquals(2, result.size());
     for (var key : result) {
       assertEquals(Integer.valueOf(144), key.getRollingPeriod());
@@ -202,9 +200,9 @@ public class GaenControllerTest extends BaseControllerTest {
 
     result =
         gaenDataService.getSortedExposedForKeyDate(
-            now.atStartOfDay().minusDays(1).getTimestamp(),
+            now.atStartOfDay().minusDays(1),
             null,
-            (now.getTimestamp() / releaseBucketDuration) * releaseBucketDuration);
+            now.roundToPreviousBucket(releaseBucketDuration));
     assertEquals(0, result.size());
   }
 
@@ -232,7 +230,7 @@ public class GaenControllerTest extends BaseControllerTest {
     for (int i = 0; i < 12; i++) {
       var tmpKey = new GaenKey();
       tmpKey.setRollingStartNumber((int) midnight.plusDays(10).get10MinutesSince1970());
-      tmpKey.setKeyData(Base64.getEncoder().encodeToString("testKey32Bytes--".getBytes("UTF-8")));
+      tmpKey.setKeyData(Base64.getEncoder().encodeToString("testKey32Bytes03".getBytes("UTF-8")));
       tmpKey.setRollingPeriod(144);
       tmpKey.setFake(0);
       tmpKey.setTransmissionRiskLevel(0);
@@ -270,10 +268,8 @@ public class GaenControllerTest extends BaseControllerTest {
 
     var result =
         gaenDataService.getSortedExposedForKeyDate(
-            midnight.minusDays(1).getTimestamp(),
-            null,
-            (now.getTimestamp() / releaseBucketDuration + 1) * releaseBucketDuration);
-    // all keys are in compatible
+            midnight.minusDays(1), null, now.roundToNextBucket(releaseBucketDuration));
+    // all keys are invalid
     assertEquals(0, result.size());
   }
 
@@ -379,16 +375,12 @@ public class GaenControllerTest extends BaseControllerTest {
 
     var result =
         gaenDataService.getSortedExposedForKeyDate(
-            midnight.minusDays(1).getTimestamp(),
-            null,
-            (now.getTimestamp() / releaseBucketDuration + 1) * releaseBucketDuration);
+            midnight.minusDays(1), null, now.roundToNextBucket(releaseBucketDuration));
     // all keys are invalid
     assertEquals(0, result.size());
     result =
         gaenDataService.getSortedExposedForKeyDate(
-            midnight.getTimestamp(),
-            null,
-            (now.getTimestamp() / releaseBucketDuration + 1) * releaseBucketDuration);
+            midnight, null, now.roundToNextBucket(releaseBucketDuration));
     // all keys are invalid
     assertEquals(0, result.size());
   }
@@ -750,9 +742,8 @@ public class GaenControllerTest extends BaseControllerTest {
             .andReturn();
     var result =
         gaenDataService.getSortedExposedForKeyDate(
-            midnight.minusDays(2).getTimestamp(),
-            null,
-            (now.getTimestamp() / releaseBucketDuration + 1) * releaseBucketDuration);
+            midnight.minusDays(2), null, now.roundToNextBucket(releaseBucketDuration));
+
     assertEquals(0, result.size());
   }
 
@@ -837,13 +828,13 @@ public class GaenControllerTest extends BaseControllerTest {
                     .header("Authorization", "Bearer " + token)
                     .header("User-Agent", androidUserAgent)
                     .content(json(exposeeRequest)))
+            .andExpect(request().asyncStarted())
             .andExpect(status().is(200))
             .andReturn();
     var result =
         gaenDataService.getSortedExposedForKeyDate(
-            midnight.plusDays(2).getTimestamp(),
-            null,
-            (now.getTimestamp() / releaseBucketDuration + 1) * releaseBucketDuration);
+            midnight.plusDays(2), null, now.roundToNextBucket(releaseBucketDuration));
+
     assertEquals(0, result.size());
   }
 
@@ -890,9 +881,7 @@ public class GaenControllerTest extends BaseControllerTest {
             .andReturn();
     var result =
         gaenDataService.getSortedExposedForKeyDate(
-            midnight.minusDays(22).getTimestamp(),
-            null,
-            (now.getTimestamp() / releaseBucketDuration + 1) * releaseBucketDuration);
+            midnight.minusDays(22), null, now.roundToNextBucket(releaseBucketDuration));
     assertEquals(0, result.size());
   }
 

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/controller/GaenControllerTest.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/controller/GaenControllerTest.java
@@ -200,9 +200,7 @@ public class GaenControllerTest extends BaseControllerTest {
 
     result =
         gaenDataService.getSortedExposedForKeyDate(
-            now.atStartOfDay().minusDays(1),
-            null,
-            now.roundToPreviousBucket(releaseBucketDuration));
+            now.atStartOfDay().minusDays(1), null, now.roundToBucketStart(releaseBucketDuration));
     assertEquals(0, result.size());
   }
 

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/insertmanager/MockDataSource.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/insertmanager/MockDataSource.java
@@ -15,16 +15,21 @@ public class MockDataSource implements GAENDataService {
 
   @Override
   public void upsertExposeesDelayed(
-      List<GaenKey> keys, UTCInstant delayedReceivedAt, UTCInstant now) {}
+      List<GaenKey> keys, UTCInstant delayedReceivedAt, UTCInstant now) {
+    throw new RuntimeException("UPSERT_EXPOSEESDelayed");
+  }
 
   @Override
-  public int getMaxExposedIdForKeyDate(Long keyDate, Long publishedAfter, Long publishedUntil) {
+  public int getMaxExposedIdForKeyDate(
+      UTCInstant keyDate, UTCInstant publishedAfter, UTCInstant publishedUntil) {
+    // TODO Auto-generated method stub
     return 0;
   }
 
   @Override
   public List<GaenKey> getSortedExposedForKeyDate(
-      Long keyDate, Long publishedAfter, Long publishedUntil) {
+      UTCInstant keyDate, UTCInstant publishedAfter, UTCInstant publishedUntil) {
+    // TODO Auto-generated method stub
     return null;
   }
 


### PR DESCRIPTION
This PR adds the two methods roundTo(BucketStart|NextBucket) to the 'UTCInstant' class.
This simplifies a lot of calculations in different parts of the code.
More conversions of 'long' to 'UTCInstant'.

Closes #232 