### PR TITLE
[WIP] V2 API for cross-country usage

### DIFF
--- a/documentation/yaml/sdk.yaml
+++ b/documentation/yaml/sdk.yaml
@@ -280,6 +280,76 @@ paths:
         required: true
         schema:
           type: string
+  /v2/gaen/exposed:
+    post:
+      summary: addExposed
+      description: Endpoint used to upload exposure keys to the backend specifying
+        for which countries the keys are valid.
+      responses:
+        '200':
+          description: The exposed keys have been stored in the database
+          content:
+            application/json:
+              schema:
+                type: string
+        '400':
+          description: '- Invalid base64 encoding in GaenRequest- negative rolling
+            period- fake claim with non-fake keys'
+        '403':
+          description: Authentication failed
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/org.dpppt.backend.sdk.model.gaen.GaenV2UploadKeysRequest'
+        description: JSON Object containing all keys and a list of countries specifying
+          for which countries the keys are valid or more precise what countries have
+          been visited
+      parameters:
+      - name: User-Agent
+        in: header
+        description: App Identifier (PackageName/BundleIdentifier) + App-Version +
+          OS (Android/iOS) + OS-Version
+        example: ch.ubique.android.starsdk;1.0;iOS;13.3
+        required: true
+        schema:
+          type: string
+    get:
+      summary: getExposedKeys
+      description: Requests the exposed keys published _since_ originating from list
+        of _country_
+      responses:
+        '200':
+          description: zipped export.bin and export.sig of all keys in that interval
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        '404':
+          description: Invalid _country_ or invalid _since_ (too far in the past/future,
+            not at bucket boundaries)
+      parameters:
+      - name: country
+        in: query
+        description: List of origin countries of requested keys. (iso-3166-1 alpha-2).
+          Must be padded with fake countries
+        example: CH
+        required: true
+        schema:
+          type: array
+          items:
+            type: string
+      - name: since
+        in: query
+        description: Timestamp to retrieve exposed keys since, in milliseconds since
+          Unix epoch (1970-01-01). It must indicate the beginning of a bucket.
+        example: '1593043200000'
+        required: true
+        schema:
+          type: integer
+          format: long
 components:
   schemas:
     org.dpppt.backend.sdk.model.BucketList:
@@ -352,6 +422,17 @@ components:
             $ref: '#/components/schemas/org.dpppt.backend.sdk.model.ExposedKey'
         fake:
           type: integer
+    org.dpppt.backend.sdk.model.gaen.CountryShareConfiguration:
+      type: object
+      properties:
+        countryCode:
+          type: string
+          description: A iso-3166-1 alpha-2 country code
+          example: '"CH"'
+        shareKeyWithCountry:
+          type: integer
+          description: 'Share key with country: 0 -> no share, 1 -> share'
+          example: '1'
     org.dpppt.backend.sdk.model.gaen.DayBuckets:
       type: object
       properties:
@@ -382,27 +463,27 @@ components:
         keyData:
           type: string
           description: Represents the 16-byte Temporary Exposure Key in base64
-          example: ''
+          example: XDM3NVwzNTZPvVwzMzNcMzA1
         rollingStartNumber:
           type: integer
           description: The ENIntervalNumber as number of 10-minute intervals since
             the Unix epoch (1970-01-01)
-          example: ''
+          example: '2659680'
         rollingPeriod:
           type: integer
           description: The TEKRollingPeriod indicates for how many 10-minute intervals
             the Temporary Exposure Key is valid
-          example: ''
+          example: '144'
         transmissionRiskLevel:
           type: integer
           description: According to the Google API description a value between 0 and
             4096, with higher values indicating a higher risk
-          example: ''
+          example: '0'
         fake:
           type: integer
           description: If fake = 0, the key is a valid key. If fake = 1, the key will
             be discarded.
-          example: ''
+          example: '1'
     org.dpppt.backend.sdk.model.gaen.GaenRequest:
       type: object
       required:
@@ -413,13 +494,20 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/org.dpppt.backend.sdk.model.gaen.GaenKey'
-          description: 14 Temporary Exposure keys - zero or more of them might be
-            fake keys
+          description: Between 14 and 30 Temporary Exposure Keys - zero or more of
+            them might be fake keys. Starting with EN 1.5 it is possible that clients
+            send more than 14 keys.
           example: ''
         delayedKeyDate:
           type: integer
-          description: Unknown - has something to do with GAEN not exposing the current
-            day's key and that the current day's key will be delivered with 24h delay
+          description: Prior to version 1.5 Exposure Keys for the day of report weren't
+            available (since they were still used throughout this day RPI=144), so
+            the submission of the last key had to be delayed. This Unix timestamp
+            in milliseconds specifies, which key date the last key (which will be
+            submitted on the next day) will have. The backend then issues a JWT to
+            allow the submission of this last key with specified key date. This should
+            not be necessary after the Exposure Framework is able to send and handle
+            keys with RollingPeriod < 144 (e.g. only valid until submission).
           example: ''
     org.dpppt.backend.sdk.model.gaen.GaenSecondDay:
       type: object
@@ -428,6 +516,26 @@ components:
       properties:
         delayedKey:
           $ref: '#/components/schemas/org.dpppt.backend.sdk.model.gaen.GaenKey'
+    org.dpppt.backend.sdk.model.gaen.GaenV2UploadKeysRequest:
+      type: object
+      required:
+      - countriesForSharingKeys
+      - gaenKeys
+      properties:
+        countriesForSharingKeys:
+          type: array
+          items:
+            $ref: '#/components/schemas/org.dpppt.backend.sdk.model.gaen.CountryShareConfiguration'
+          description: List of all countries configured. For each country in the list,
+            sharing must be explicitly set
+          example: ''
+        gaenKeys:
+          type: array
+          items:
+            $ref: '#/components/schemas/org.dpppt.backend.sdk.model.gaen.GaenKey'
+          description: 30 Temporary Exposure Keys - zero or more of them might be
+            fake keys.
+          example: ''
     org.dpppt.backend.sdk.model.proto.Exposed.ProtoExposedList:
       type: object
       properties:

--- a/documentation/yaml/sdk.yaml
+++ b/documentation/yaml/sdk.yaml
@@ -167,8 +167,7 @@ paths:
               schema:
                 type: string
         '400':
-          description: '- Invalid base64 encoding in GaenRequest- negative rolling
-            period- fake claim with non-fake keys'
+          description: Invalid base64 encoding in GaenRequest
         '403':
           description: Authentication failed
       requestBody:
@@ -203,7 +202,7 @@ paths:
                 type: string
         '400':
           description: '- Ivnalid base64 encoded Temporary Exposure Key- TEK-date
-            does not match delayedKeyDAte claim in Jwt- TEK has negative rolling period'
+            does not match delayedKeyDAte claim in Jwt'
         '403':
           description: No delayedKeyDate claim in authentication
       requestBody:
@@ -451,7 +450,6 @@ components:
           items:
             type: string
           description: Relative URLs for the available release buckets
-          example: '[''/exposed/1593043200000'', ''/exposed/1593046800000'''
     org.dpppt.backend.sdk.model.gaen.GaenKey:
       type: object
       required:
@@ -497,7 +495,6 @@ components:
           description: Between 14 and 30 Temporary Exposure Keys - zero or more of
             them might be fake keys. Starting with EN 1.5 it is possible that clients
             send more than 14 keys.
-          example: ''
         delayedKeyDate:
           type: integer
           description: Prior to version 1.5 Exposure Keys for the day of report weren't
@@ -528,14 +525,12 @@ components:
             $ref: '#/components/schemas/org.dpppt.backend.sdk.model.gaen.CountryShareConfiguration'
           description: List of all countries configured. For each country in the list,
             sharing must be explicitly set
-          example: ''
         gaenKeys:
           type: array
           items:
             $ref: '#/components/schemas/org.dpppt.backend.sdk.model.gaen.GaenKey'
           description: 30 Temporary Exposure Keys - zero or more of them might be
             fake keys.
-          example: ''
     org.dpppt.backend.sdk.model.proto.Exposed.ProtoExposedList:
       type: object
       properties:

--- a/dpppt-backend-sdk/dpppt-backend-sdk-model/src/main/java/org/dpppt/backend/sdk/model/gaen/CountryShareConfiguration.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-model/src/main/java/org/dpppt/backend/sdk/model/gaen/CountryShareConfiguration.java
@@ -1,0 +1,37 @@
+package org.dpppt.backend.sdk.model.gaen;
+
+import ch.ubique.openapi.docannotations.Documentation;
+import javax.validation.Valid;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.Size;
+
+public class CountryShareConfiguration {
+
+  @Valid
+  @Size(max = 2, min = 2)
+  @Documentation(description = "A iso-3166-1 alpha-2 country code", example = "\"CH\"")
+  private String countryCode;
+
+  @Valid
+  @Min(value = 0)
+  @Max(value = 1)
+  @Documentation(description = "Share key with country: 0 -> no share, 1 -> share", example = "1")
+  private int shareKeyWithCountry = 0;
+
+  public String getCountryCode() {
+    return countryCode;
+  }
+
+  public void setCountryCode(String countryCode) {
+    this.countryCode = countryCode;
+  }
+
+  public int getShareKeyWithCountry() {
+    return shareKeyWithCountry;
+  }
+
+  public void setShareKeyWithCountry(int shareKeyWithCountry) {
+    this.shareKeyWithCountry = shareKeyWithCountry;
+  }
+}

--- a/dpppt-backend-sdk/dpppt-backend-sdk-model/src/main/java/org/dpppt/backend/sdk/model/gaen/GaenKey.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-model/src/main/java/org/dpppt/backend/sdk/model/gaen/GaenKey.java
@@ -13,31 +13,38 @@ public class GaenKey {
 
   @NotNull
   @Size(min = 24, max = 24)
-  @Documentation(description = "Represents the 16-byte Temporary Exposure Key in base64")
+  @Documentation(
+      description = "Represents the 16-byte Temporary Exposure Key in base64",
+      example = "XDM3NVwzNTZPvVwzMzNcMzA1")
   private String keyData;
 
   @NotNull
   @Documentation(
       description =
-          "The ENIntervalNumber as number of 10-minute intervals since the Unix epoch (1970-01-01)")
+          "The ENIntervalNumber as number of 10-minute intervals since the Unix epoch (1970-01-01)",
+      example = "2659680")
   private Integer rollingStartNumber;
 
   @NotNull
   @Documentation(
       description =
           "The TEKRollingPeriod indicates for how many 10-minute intervals the Temporary Exposure"
-              + " Key is valid")
+              + " Key is valid",
+      example = "144")
   private Integer rollingPeriod;
 
   @NotNull
+  @Deprecated
   @Documentation(
       description =
           "According to the Google API description a value between 0 and 4096, with higher values"
-              + " indicating a higher risk")
+              + " indicating a higher risk",
+      example = "0")
   private Integer transmissionRiskLevel;
 
   @Documentation(
-      description = "If fake = 0, the key is a valid key. If fake = 1, the key will be discarded.")
+      description = "If fake = 0, the key is a valid key. If fake = 1, the key will be discarded.",
+      example = "1")
   private Integer fake = 0;
 
   public GaenKey() {}

--- a/dpppt-backend-sdk/dpppt-backend-sdk-model/src/main/java/org/dpppt/backend/sdk/model/gaen/GaenV2UploadKeysRequest.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-model/src/main/java/org/dpppt/backend/sdk/model/gaen/GaenV2UploadKeysRequest.java
@@ -1,0 +1,44 @@
+package org.dpppt.backend.sdk.model.gaen;
+
+import ch.ubique.openapi.docannotations.Documentation;
+import java.util.List;
+import javax.validation.Valid;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+public class GaenV2UploadKeysRequest {
+
+  @NotNull
+  @NotEmpty
+  @Valid
+  @Documentation(
+      description =
+          "List of all countries configured. For each country in the list, sharing must be"
+              + " explicitly set")
+  List<CountryShareConfiguration> countriesForSharingKeys;
+
+  @NotNull
+  @NotEmpty
+  @Valid
+  @Size(min = 30, max = 30)
+  @Documentation(
+      description = "30 Temporary Exposure Keys - zero or more of them might be fake keys.")
+  private List<GaenKey> gaenKeys;
+
+  public List<GaenKey> getGaenKeys() {
+    return this.gaenKeys;
+  }
+
+  public void setGaenKeys(List<GaenKey> gaenKeys) {
+    this.gaenKeys = gaenKeys;
+  }
+
+  public List<CountryShareConfiguration> getCountriesForSharingKeys() {
+    return countriesForSharingKeys;
+  }
+
+  public void setCountriesForSharingKeys(List<CountryShareConfiguration> countriesForSharingKeys) {
+    this.countriesForSharingKeys = countriesForSharingKeys;
+  }
+}

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/pom.xml
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/pom.xml
@@ -155,7 +155,7 @@
 			<plugin>
                 <groupId>ch.ubique.openapi</groupId>
                 <artifactId>springboot-swagger-3</artifactId>
-                <version>1.2.8</version>
+                <version>1.2.10</version>
                 <configuration>
                     <apiVersion>1.0-gapple</apiVersion>
                     <basePackages>
@@ -170,6 +170,7 @@
                     <controllers>
                         <controller>org.dpppt.backend.sdk.ws.controller.DPPPTController</controller>
 						<controller> org.dpppt.backend.sdk.ws.controller.GaenController</controller>
+						<controller>org.dpppt.backend.sdk.ws.controller.GaenV2Controller</controller>
                     </controllers>
                     <description>DP3T API</description>
                     <apiUrls>

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/pom.xml
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/pom.xml
@@ -155,7 +155,7 @@
 			<plugin>
                 <groupId>ch.ubique.openapi</groupId>
                 <artifactId>springboot-swagger-3</artifactId>
-                <version>1.2.10</version>
+                <version>1.2.11</version>
                 <configuration>
                     <apiVersion>1.0-gapple</apiVersion>
                     <basePackages>

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/GaenV2Controller.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/GaenV2Controller.java
@@ -1,0 +1,96 @@
+package org.dpppt.backend.sdk.ws.controller;
+
+import ch.ubique.openapi.docannotations.Documentation;
+import java.util.List;
+import org.dpppt.backend.sdk.model.gaen.GaenV2UploadKeysRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+/**
+ * This is a new controller to simplify the sending and receiving of keys. It will be used by the
+ * new SwissCovid client and allows for cross-country usage.
+ */
+@Controller
+@RequestMapping("/v2/gaen")
+@Documentation(
+    description =
+        "The GAEN V2 endpoint for the mobile clients supporting international key sharing")
+public class GaenV2Controller {
+
+  /**
+   * This API includes the implicit design decision that the list of visited countries * applies to
+   * all keys (rather than per key). * This design decision makes sense to us for two reasons: * 1.
+   * Detailed per-day travel information is not available from the current UI * 2. For simplicity
+   * the UI should probably also not aim to request this information
+   */
+  @PostMapping(value = "/exposed")
+  @Documentation(
+      description =
+          "Endpoint used to upload exposure keys to the backend specifying for which countries the"
+              + " keys are valid.",
+      responses = {
+        "200=>The exposed keys have been stored in the database",
+        "400=> "
+            + "- Invalid base64 encoding in GaenRequest"
+            + "- negative rolling period"
+            + "- fake claim with non-fake keys",
+        "403=>Authentication failed"
+      })
+  public @ResponseBody ResponseEntity<String> addExposed(
+      @Documentation(
+              description =
+                  "JSON Object containing all keys and a list of countries specifying for which"
+                      + " countries the keys are valid or more precise what countries have been"
+                      + " visited")
+          @RequestBody
+          GaenV2UploadKeysRequest gaenV2Request,
+      @RequestHeader(value = "User-Agent")
+          @Documentation(
+              description =
+                  "App Identifier (PackageName/BundleIdentifier) + App-Version + OS (Android/iOS)"
+                      + " + OS-Version",
+              example = "ch.ubique.android.starsdk;1.0;iOS;13.3")
+          String userAgent,
+      @AuthenticationPrincipal
+          @Documentation(description = "JWT token that can be verified by the backend server")
+          Object principal) {
+    return null;
+  }
+
+  // GET for Key Download
+  @GetMapping(value = "/exposed")
+  @Documentation(
+      description =
+          "Requests the exposed keys published _since_ originating from list of _country_",
+      responses = {
+        "200 => zipped export.bin and export.sig of all keys in that interval",
+        "404 => Invalid _country_ or invalid _since_ (too far in the past/future, not at bucket"
+            + " boundaries)"
+      })
+  public @ResponseBody ResponseEntity<byte[]> getExposedKeys(
+      @Documentation(
+              description =
+                  "List of origin countries of requested keys. (iso-3166-1 alpha-2). Must be"
+                      + " padded with fake countries",
+              example = "CH")
+          @RequestParam
+          List<String> country,
+      @Documentation(
+              description =
+                  "Timestamp to retrieve exposed keys since, in milliseconds since Unix epoch"
+                      + " (1970-01-01). It must indicate the beginning of a bucket.",
+              example = "1593043200000")
+          @RequestParam
+          long since) {
+
+    return null;
+  }
+}


### PR DESCRIPTION
Key sharing with country code and shared flag:

This allows that clients can always send the full list of countries that are configured and setting
the share flag for each country. This makes sure that fake upload requests can not be distinguished from non-fake uploads