### PR TITLE
InsertManager cleanup

### DIFF
--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/config/WSBaseConfig.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/config/WSBaseConfig.java
@@ -35,12 +35,12 @@ import org.dpppt.backend.sdk.ws.controller.DPPPTController;
 import org.dpppt.backend.sdk.ws.controller.GaenController;
 import org.dpppt.backend.sdk.ws.filter.ResponseWrapperFilter;
 import org.dpppt.backend.sdk.ws.insertmanager.InsertManager;
-import org.dpppt.backend.sdk.ws.insertmanager.insertionfilters.Base64Filter;
-import org.dpppt.backend.sdk.ws.insertmanager.insertionfilters.KeysMatchingJWTFilter;
-import org.dpppt.backend.sdk.ws.insertmanager.insertionfilters.NonFakeKeysFilter;
-import org.dpppt.backend.sdk.ws.insertmanager.insertionfilters.RollingStartNumberAfterDayAfterTomorrowFilter;
-import org.dpppt.backend.sdk.ws.insertmanager.insertionfilters.RollingStartNumberInRetentionPeriodFilter;
-import org.dpppt.backend.sdk.ws.insertmanager.insertionfilters.ValidRollingPeriodFilter;
+import org.dpppt.backend.sdk.ws.insertmanager.insertionfilters.AssertBase64;
+import org.dpppt.backend.sdk.ws.insertmanager.insertionfilters.EnforceMatchingJWTClaims;
+import org.dpppt.backend.sdk.ws.insertmanager.insertionfilters.EnforceRetentionPeriod;
+import org.dpppt.backend.sdk.ws.insertmanager.insertionfilters.EnforceValidRollingPeriod;
+import org.dpppt.backend.sdk.ws.insertmanager.insertionfilters.RemoveFakeKeys;
+import org.dpppt.backend.sdk.ws.insertmanager.insertionfilters.RemoveKeysFromFuture;
 import org.dpppt.backend.sdk.ws.insertmanager.insertionmodifier.IOSLegacyProblemRPLT144Modifier;
 import org.dpppt.backend.sdk.ws.insertmanager.insertionmodifier.OldAndroid0RPModifier;
 import org.dpppt.backend.sdk.ws.interceptor.HeaderInjector;
@@ -216,12 +216,12 @@ public abstract class WSBaseConfig implements SchedulingConfigurer, WebMvcConfig
   @Bean
   public InsertManager insertManager() {
     var manager = new InsertManager(gaenDataService(), gaenValidationUtils());
-    manager.addFilter(new Base64Filter(gaenValidationUtils()));
-    manager.addFilter(new KeysMatchingJWTFilter(gaenRequestValidator, gaenValidationUtils()));
-    manager.addFilter(new RollingStartNumberAfterDayAfterTomorrowFilter());
-    manager.addFilter(new RollingStartNumberInRetentionPeriodFilter(gaenValidationUtils()));
-    manager.addFilter(new NonFakeKeysFilter());
-    manager.addFilter(new ValidRollingPeriodFilter());
+    manager.addFilter(new AssertBase64(gaenValidationUtils()));
+    manager.addFilter(new EnforceMatchingJWTClaims(gaenRequestValidator, gaenValidationUtils()));
+    manager.addFilter(new RemoveKeysFromFuture());
+    manager.addFilter(new EnforceRetentionPeriod(gaenValidationUtils()));
+    manager.addFilter(new RemoveFakeKeys());
+    manager.addFilter(new EnforceValidRollingPeriod());
     return manager;
   }
 

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/insertmanager/insertionfilters/EnforceRetentionPeriod.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/insertmanager/insertionfilters/EnforceRetentionPeriod.java
@@ -13,19 +13,14 @@ import org.dpppt.backend.sdk.ws.util.ValidationUtils;
  * Checks if a key is in the configured retention period. If a key is before the retention period it
  * is filtered out, as it will not be relevant for the system anymore.
  */
-public class RollingStartNumberInRetentionPeriodFilter implements KeyInsertionFilter {
+public class EnforceRetentionPeriod implements KeyInsertionFilter {
 
   private final ValidationUtils validationUtils;
 
-  public RollingStartNumberInRetentionPeriodFilter(ValidationUtils validationUtils) {
+  public EnforceRetentionPeriod(ValidationUtils validationUtils) {
     this.validationUtils = validationUtils;
   }
 
-  /**
-   * Loops through all the keys and converts the rolling start number to a timestamp. Using {@link
-   * ValidationUtils#isBeforeRetention(UTCInstant, UTCInstant)} only keys are accepted that are not
-   * before the retention period. Keys before the retention period are filtered out.
-   */
   @Override
   public List<GaenKey> filter(
       UTCInstant now,

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/insertmanager/insertionfilters/EnforceValidRollingPeriod.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/insertmanager/insertionfilters/EnforceValidRollingPeriod.java
@@ -13,9 +13,8 @@ import org.dpppt.backend.sdk.ws.insertmanager.OSType;
  * "https://github.com/google/exposure-notifications-server/blob/main/docs/server_functional_requirements.md#publishing-temporary-exposure-keys"
  * >EN documentation</a>
  */
-public class ValidRollingPeriodFilter implements KeyInsertionFilter {
+public class EnforceValidRollingPeriod implements KeyInsertionFilter {
 
-  /** Loop through given keys and filter out keys which have rolling period < 1 or > 144. */
   @Override
   public List<GaenKey> filter(
       UTCInstant now,

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/insertmanager/insertionfilters/RemoveFakeKeys.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/insertmanager/insertionfilters/RemoveFakeKeys.java
@@ -7,16 +7,9 @@ import org.dpppt.backend.sdk.semver.Version;
 import org.dpppt.backend.sdk.utils.UTCInstant;
 import org.dpppt.backend.sdk.ws.insertmanager.OSType;
 
-/**
- * Filters out fake keys from fake upload requests. Only Non-Fake keys are inserted into the
- * database.
- */
-public class NonFakeKeysFilter implements KeyInsertionFilter {
+/** Keep only Non-Fake keys, so that fake keys are not stored in the database. */
+public class RemoveFakeKeys implements KeyInsertionFilter {
 
-  /**
-   * Loops through the list of given keys and checks the fake flag. Only return keys that have fake
-   * flag set to 0
-   */
   @Override
   public List<GaenKey> filter(
       UTCInstant now,

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/insertmanager/insertionfilters/RemoveKeysFromFuture.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/insertmanager/insertionfilters/RemoveKeysFromFuture.java
@@ -9,15 +9,10 @@ import org.dpppt.backend.sdk.utils.UTCInstant;
 import org.dpppt.backend.sdk.ws.insertmanager.OSType;
 
 /**
- * Checks if a key has rolling start number after the day after tomorrow. If so, the key is filtered
- * out, as this is not allowed by the system to insert keys too far in the future.
+ * Reject keys that are too far in the future. The `rollingStart` must not be later than tomorrow.
  */
-public class RollingStartNumberAfterDayAfterTomorrowFilter implements KeyInsertionFilter {
+public class RemoveKeysFromFuture implements KeyInsertionFilter {
 
-  /**
-   * Loops through all the keys and converts the rolling start number to a timstamp. The it is
-   * checked if the timestamp is before now + 2 days.
-   */
   @Override
   public List<GaenKey> filter(
       UTCInstant now,

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/insertmanager/insertionmodifier/IOSLegacyProblemRPLT144Modifier.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/insertmanager/insertionmodifier/IOSLegacyProblemRPLT144Modifier.java
@@ -7,11 +7,16 @@ import org.dpppt.backend.sdk.utils.UTCInstant;
 import org.dpppt.backend.sdk.ws.insertmanager.OSType;
 
 /**
- * This key modifier makes sure, that rolling period is always set to 144. Default value according
- * to EN is 144, so just set it to that. This allows to check for the Google-TEKs also on iOS.
- * Because the Rolling Proximity Identifier is based on the TEK and the unix epoch, this should
- * work. The only downside is that iOS will not be able to optimize verification of the TEKs,
- * because it will have to consider each TEK for a whole day.
+ * Overwrite the rolling period with the default value of 144 so that iOS does not reject the keys.
+ * Since version 1.5 of the GAEN on Android, TEKs with a rolling period < 144 can be released.
+ * Unfortunately these keys are rejected by iOS, so this filter sets the default value. There are
+ * two downsides to this:
+ *
+ * <ul>
+ *   <li>some more work for the GAEN to verify the keys
+ *   <li>a same-day key with original rolling period < 144 will be released later and thus delay
+ *       detection of an eventual exposition
+ * </ul>
  */
 public class IOSLegacyProblemRPLT144Modifier implements KeyInsertionModifier {
 

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/insertmanager/insertionmodifier/OldAndroid0RPModifier.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/insertmanager/insertionmodifier/OldAndroid0RPModifier.java
@@ -20,11 +20,6 @@ public class OldAndroid0RPModifier implements KeyInsertionModifier {
 
   private static final Logger logger = LoggerFactory.getLogger(OldAndroid0RPModifier.class);
 
-  /**
-   * Loop through all the given keys and check if the rolling period is equal to 0. If so, set to
-   * 144. In case a key with rolling period 0 is received from an iOS client, an error log is
-   * printed.
-   */
   @Override
   public List<GaenKey> modify(
       UTCInstant now,
@@ -35,9 +30,7 @@ public class OldAndroid0RPModifier implements KeyInsertionModifier {
       Object principal) {
     for (GaenKey gaenKey : content) {
       if (gaenKey.getRollingPeriod().equals(0)) {
-        if (osType.equals(OSType.IOS)) {
-          logger.error("We got a rollingPeriod of 0 ({},{},{})", osType, osVersion, appVersion);
-        }
+        logger.error("We got a rollingPeriod of 0 ({},{},{})", osType, osVersion, appVersion);
         gaenKey.setRollingPeriod(144);
       }
     }

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/util/ValidationUtils.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/util/ValidationUtils.java
@@ -11,7 +11,7 @@ package org.dpppt.backend.sdk.ws.util;
 
 import java.time.Duration;
 import java.util.Base64;
-import org.dpppt.backend.sdk.model.gaen.GaenKey;
+import org.dpppt.backend.sdk.model.gaen.GaenUnit;
 import org.dpppt.backend.sdk.utils.UTCInstant;
 import org.springframework.security.oauth2.jwt.Jwt;
 
@@ -101,7 +101,7 @@ public class ValidationUtils {
     return this.isDateInRange(batchReleaseTime, now);
   }
 
-  public void validateDelayedKeyDate(UTCInstant now, UTCInstant delayedKeyDate)
+  public void assertDelayedKeyDate(UTCInstant now, UTCInstant delayedKeyDate)
       throws DelayedKeyDateIsInvalid {
     if (delayedKeyDate.isBeforeDateOf(now.getLocalDate().minusDays(1))
         || delayedKeyDate.isAfterDateOf(now.getLocalDate().plusDays(1))) {
@@ -109,19 +109,15 @@ public class ValidationUtils {
     }
   }
 
-  public void checkForDelayedKeyDateClaim(Object principal, GaenKey delayedKey)
-      throws DelayedKeyDateClaimIsWrong {
-    if (principal instanceof Jwt
-        && Boolean.FALSE.equals(((Jwt) principal).containsClaim("delayedKeyDate"))) {
-      throw new DelayedKeyDateClaimIsWrong();
-    }
+  public UTCInstant getDelayedKeyDateClaim(Object principal) throws DelayedKeyDateClaimIsMissing {
     if (principal instanceof Jwt) {
       var jwt = (Jwt) principal;
-      var claimKeyDate = Integer.parseInt(jwt.getClaimAsString("delayedKeyDate"));
-      if (!delayedKey.getRollingStartNumber().equals(claimKeyDate)) {
-        throw new DelayedKeyDateClaimIsWrong();
+      if (jwt.containsClaim("delayedKeyDate")) {
+        return UTCInstant.of(
+            Integer.parseInt(jwt.getClaimAsString("delayedKeyDate")), GaenUnit.TenMinutes);
       }
     }
+    throw new DelayedKeyDateClaimIsMissing();
   }
 
   public boolean jwtIsFake(Object principal) {
@@ -141,7 +137,7 @@ public class ValidationUtils {
     private static final long serialVersionUID = -2667236967819549686L;
   }
 
-  public class DelayedKeyDateClaimIsWrong extends Exception {
+  public class DelayedKeyDateClaimIsMissing extends Exception {
 
     /** */
     private static final long serialVersionUID = 4683923905451080793L;


### PR DESCRIPTION
This PR updates the comments of the filters and modifiers to follow 'plain English':
http://www.plainenglish.co.uk/how-to-write-in-plain-english.html

Also changed ValidationUtils.checkForDelayedKeyDateClaim and its use in the KeysMatchingJWTFilter
which was wrong.