### PR TITLE
Split JWTClaims filter for Exposed and ExposedNextDay

### DIFF
--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/GaenController.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/GaenController.java
@@ -27,7 +27,6 @@ import javax.validation.Valid;
 import org.dpppt.backend.sdk.data.gaen.FakeKeyService;
 import org.dpppt.backend.sdk.data.gaen.GAENDataService;
 import org.dpppt.backend.sdk.model.gaen.DayBuckets;
-import org.dpppt.backend.sdk.model.gaen.GaenKey;
 import org.dpppt.backend.sdk.model.gaen.GaenRequest;
 import org.dpppt.backend.sdk.model.gaen.GaenSecondDay;
 import org.dpppt.backend.sdk.model.gaen.GaenUnit;
@@ -86,7 +85,8 @@ public class GaenController {
   private final Duration requestTime;
   private final ValidateRequest validateRequest;
   private final ValidationUtils validationUtils;
-  private final InsertManager insertManager;
+  private final InsertManager insertManagerExposed;
+  private final InsertManager insertManagerExposedNextDay;
   private final GAENDataService dataService;
   private final FakeKeyService fakeKeyService;
   private final Duration exposedListCacheControl;
@@ -94,7 +94,8 @@ public class GaenController {
   private final ProtoSignature gaenSigner;
 
   public GaenController(
-      InsertManager insertManager,
+      InsertManager insertManagerExposed,
+      InsertManager insertManagerExposedNextDay,
       GAENDataService dataService,
       FakeKeyService fakeKeyService,
       ValidateRequest validateRequest,
@@ -104,7 +105,8 @@ public class GaenController {
       Duration requestTime,
       Duration exposedListCacheControl,
       PrivateKey secondDayKey) {
-    this.insertManager = insertManager;
+    this.insertManagerExposed = insertManagerExposed;
+    this.insertManagerExposedNextDay = insertManagerExposedNextDay;
     this.dataService = dataService;
     this.fakeKeyService = fakeKeyService;
     this.releaseBucketDuration = releaseBucketDuration;
@@ -145,14 +147,14 @@ public class GaenController {
       @AuthenticationPrincipal
           @Documentation(description = "JWT token that can be verified by the backend server")
           Object principal)
-      throws WrongScopeException, KeyIsNotBase64Exception, DelayedKeyDateIsInvalid {
+      throws DelayedKeyDateIsInvalid, InsertException, WrongScopeException {
     var now = UTCInstant.now();
 
     this.validateRequest.isValid(principal);
 
     // Filter out non valid keys and insert them into the database (c.f. InsertManager and
     // configured Filters in the WSBaseConfig)
-    insertIntoDatabaseIfJWTIsNotFake(gaenRequest.getGaenKeys(), userAgent, principal, now);
+    insertManagerExposed.insertIntoDatabase(gaenRequest.getGaenKeys(), userAgent, principal, now);
 
     this.validationUtils.assertDelayedKeyDate(
         now, UTCInstant.of(gaenRequest.getDelayedKeyDate(), GaenUnit.TenMinutes));
@@ -215,7 +217,7 @@ public class GaenController {
                   "JWT token that can be verified by the backend server, must have been created by"
                       + " /v1/gaen/exposed and contain the delayedKeyDate")
           Object principal)
-      throws KeyIsNotBase64Exception, DelayedKeyDateClaimIsMissing {
+      throws DelayedKeyDateClaimIsMissing, InsertException {
     var now = UTCInstant.now();
 
     // Throws an exception if the claim doesn't exist. The actual verification is done in the
@@ -224,7 +226,8 @@ public class GaenController {
 
     // Filter out non valid keys and insert them into the database (c.f. InsertManager and
     // configured Filters in the WSBaseConfig)
-    insertIntoDatabaseIfJWTIsNotFake(gaenSecondDay.getDelayedKey(), userAgent, principal, now);
+    insertManagerExposedNextDay.insertIntoDatabase(
+        List.of(gaenSecondDay.getDelayedKey()), userAgent, principal, now);
 
     return () -> {
       try {
@@ -329,26 +332,6 @@ public class GaenController {
     }
 
     return ResponseEntity.ok(dayBuckets);
-  }
-
-  private void insertIntoDatabaseIfJWTIsNotFake(
-      GaenKey key, String userAgent, Object principal, UTCInstant now)
-      throws KeyIsNotBase64Exception {
-    List<GaenKey> keys = new ArrayList<>();
-    keys.add(key);
-    insertIntoDatabaseIfJWTIsNotFake(keys, userAgent, principal, now);
-  }
-
-  private void insertIntoDatabaseIfJWTIsNotFake(
-      List<GaenKey> keys, String userAgent, Object principal, UTCInstant now)
-      throws KeyIsNotBase64Exception {
-    try {
-      insertManager.insertIntoDatabase(keys, userAgent, principal, now);
-    } catch (KeyIsNotBase64Exception ex) {
-      throw ex;
-    } catch (InsertException ex) {
-      logger.info("Unknown exception thrown: ", ex);
-    }
   }
 
   @ExceptionHandler({DelayedKeyDateClaimIsMissing.class})

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/insertmanager/InsertException.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/insertmanager/InsertException.java
@@ -1,6 +1,6 @@
 package org.dpppt.backend.sdk.ws.insertmanager;
 
-public class InsertException extends Exception {
+public abstract class InsertException extends Exception {
 
   /** */
   private static final long serialVersionUID = 6476089262577182680L;

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/insertmanager/insertionfilters/EnforceMatchingJWTClaimsForExposed.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/insertmanager/insertionfilters/EnforceMatchingJWTClaimsForExposed.java
@@ -1,0 +1,47 @@
+package org.dpppt.backend.sdk.ws.insertmanager.insertionfilters;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.dpppt.backend.sdk.model.gaen.GaenKey;
+import org.dpppt.backend.sdk.semver.Version;
+import org.dpppt.backend.sdk.utils.UTCInstant;
+import org.dpppt.backend.sdk.ws.insertmanager.OSType;
+import org.dpppt.backend.sdk.ws.security.ValidateRequest;
+import org.dpppt.backend.sdk.ws.security.ValidateRequest.ClaimIsBeforeOnsetException;
+import org.dpppt.backend.sdk.ws.security.ValidateRequest.InvalidDateException;
+
+/**
+ * This filter compares the supplied keys from the exposed request with information found in the JWT
+ * token: the key dates must be >= the onset date, which was set by the health authority and is
+ * available as a claim in the JWT
+ */
+public class EnforceMatchingJWTClaimsForExposed implements KeyInsertionFilter {
+
+  private final ValidateRequest validateRequest;
+
+  public EnforceMatchingJWTClaimsForExposed(ValidateRequest validateRequest) {
+    this.validateRequest = validateRequest;
+  }
+
+  @Override
+  public List<GaenKey> filter(
+      UTCInstant now,
+      List<GaenKey> content,
+      OSType osType,
+      Version osVersion,
+      Version appVersion,
+      Object principal) {
+    return content.stream()
+        .filter(key -> isValidKeyDate(key, principal, now))
+        .collect(Collectors.toList());
+  }
+
+  private boolean isValidKeyDate(GaenKey key, Object principal, UTCInstant now) {
+    try {
+      validateRequest.validateKeyDate(now, principal, key);
+      return true;
+    } catch (InvalidDateException | ClaimIsBeforeOnsetException es) {
+      return false;
+    }
+  }
+}

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/insertmanager/insertionfilters/EnforceMatchingJWTClaimsForExposedNextDay.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/insertmanager/insertionfilters/EnforceMatchingJWTClaimsForExposedNextDay.java
@@ -7,31 +7,20 @@ import org.dpppt.backend.sdk.model.gaen.GaenUnit;
 import org.dpppt.backend.sdk.semver.Version;
 import org.dpppt.backend.sdk.utils.UTCInstant;
 import org.dpppt.backend.sdk.ws.insertmanager.OSType;
-import org.dpppt.backend.sdk.ws.security.ValidateRequest;
-import org.dpppt.backend.sdk.ws.security.ValidateRequest.ClaimIsBeforeOnsetException;
-import org.dpppt.backend.sdk.ws.security.ValidateRequest.InvalidDateException;
 import org.dpppt.backend.sdk.ws.util.ValidationUtils;
 import org.dpppt.backend.sdk.ws.util.ValidationUtils.DelayedKeyDateClaimIsMissing;
 import org.dpppt.backend.sdk.ws.util.ValidationUtils.DelayedKeyDateIsInvalid;
 
 /**
- * * This filter compares the supplied keys with information found in the JWT token. Depending on
- * the request, the following checks are made:
- *
- * <ul>
- *   <li>`exposed`: the key dates must be >= the onset date, which was set by the health authority
- *       and is available as a claim in the JWT
- *   <li>`exposednextday`: the supplied key must match `delayedKeyDate`, which has been set as a
- *       claim by a previous call to `exposed`
- * </ul>
+ * This filter compares the supplied keys from the exposed next day request with information found
+ * in the JWT token: the supplied key must match `delayedKeyDate`, which has been set as a claim by
+ * a previous call to `exposed`
  */
-public class EnforceMatchingJWTClaims implements KeyInsertionFilter {
+public class EnforceMatchingJWTClaimsForExposedNextDay implements KeyInsertionFilter {
 
-  private final ValidateRequest validateRequest;
   private final ValidationUtils validationUtils;
 
-  public EnforceMatchingJWTClaims(ValidateRequest validateRequest, ValidationUtils utils) {
-    this.validateRequest = validateRequest;
+  public EnforceMatchingJWTClaimsForExposedNextDay(ValidationUtils utils) {
     this.validationUtils = utils;
   }
 
@@ -50,27 +39,15 @@ public class EnforceMatchingJWTClaims implements KeyInsertionFilter {
                 // getDelayedKeyDateClaim throws an exception if there is no delayedKeyDate claim
                 // available.
                 var delayedKeyDateClaim = validationUtils.getDelayedKeyDateClaim(principal);
-                // Found a delayedKeyDate claim, so it must be `/exposednextday`
                 var delayedKeyDate =
                     UTCInstant.of(key.getRollingStartNumber(), GaenUnit.TenMinutes);
                 return delayedKeyDateClaim.equals(delayedKeyDate)
                     && isValidDelayedKeyDate(now, delayedKeyDate);
-
               } catch (DelayedKeyDateClaimIsMissing ex) {
-                // Didn't find a delayedKeyDate claim, so it must be `/exposed`
-                return isValidKeyDate(key, principal, now);
+                return false;
               }
             })
         .collect(Collectors.toList());
-  }
-
-  private boolean isValidKeyDate(GaenKey key, Object principal, UTCInstant now) {
-    try {
-      validateRequest.validateKeyDate(now, principal, key);
-      return true;
-    } catch (InvalidDateException | ClaimIsBeforeOnsetException es) {
-      return false;
-    }
   }
 
   private boolean isValidDelayedKeyDate(UTCInstant now, UTCInstant delayedKeyDate) {


### PR DESCRIPTION
This PR splits JWTClaims filter and introduces 2 different insert manager beans, one for the exposed request, and one for the exposed next day request.
Additionally, we simplify Exception Handling in controller and make InsertException abstract.

Closes #240 