### PR TITLE
[WIP] Debug methods for insertmanager

### DIFF
--- a/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/gaen/DebugGAENDataService.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/gaen/DebugGAENDataService.java
@@ -10,9 +10,11 @@
 
 package org.dpppt.backend.sdk.data.gaen;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import org.dpppt.backend.sdk.model.gaen.GaenKey;
+import org.dpppt.backend.sdk.utils.UTCInstant;
 
 public interface DebugGAENDataService {
 
@@ -32,5 +34,5 @@ public interface DebugGAENDataService {
    * @return all exposed keys for the given batch from the debug store
    */
   Map<String, List<GaenKey>> getSortedExposedForBatchReleaseTime(
-      Long batchReleaseTime, long releaseBucketDuration);
+      UTCInstant batchReleaseTime, Duration releaseBucketDuration);
 }

--- a/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/gaen/DebugJDBCGAENDataServiceImpl.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/gaen/DebugJDBCGAENDataServiceImpl.java
@@ -10,6 +10,7 @@
 
 package org.dpppt.backend.sdk.data.gaen;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -71,15 +72,14 @@ public class DebugJDBCGAENDataServiceImpl implements DebugGAENDataService {
   @Override
   @Transactional(readOnly = true)
   public Map<String, List<GaenKey>> getSortedExposedForBatchReleaseTime(
-      Long batchReleaseTime, long releaseBucketDuration) {
+      UTCInstant batchReleaseTime, Duration releaseBucketDuration) {
     String sql =
         "select pk_exposed_id, device_name, key, rolling_start_number, rolling_period,"
             + " transmission_risk_level from t_debug_gaen_exposed where received_at >= :startBatch"
             + " and received_at < :batchReleaseTime order by pk_exposed_id desc";
     MapSqlParameterSource params = new MapSqlParameterSource();
-    params.addValue("batchReleaseTime", UTCInstant.ofEpochMillis(batchReleaseTime).getDate());
-    params.addValue(
-        "startBatch", UTCInstant.ofEpochMillis(batchReleaseTime - releaseBucketDuration).getDate());
+    params.addValue("batchReleaseTime", batchReleaseTime.getDate());
+    params.addValue("startBatch", batchReleaseTime.minus(releaseBucketDuration).getDate());
     return jt.query(sql, params, new DebugGaenKeyResultSetExtractor());
   }
 }

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/DebugController.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/DebugController.java
@@ -1,30 +1,35 @@
 package org.dpppt.backend.sdk.ws.controller;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.IOException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SignatureException;
 import java.time.Duration;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
-import java.util.List;
 import javax.validation.Valid;
 import org.dpppt.backend.sdk.data.gaen.DebugGAENDataService;
 import org.dpppt.backend.sdk.model.gaen.DayBuckets;
-import org.dpppt.backend.sdk.model.gaen.GaenKey;
 import org.dpppt.backend.sdk.model.gaen.GaenRequest;
 import org.dpppt.backend.sdk.utils.UTCInstant;
+import org.dpppt.backend.sdk.ws.insertmanager.InsertException;
+import org.dpppt.backend.sdk.ws.insertmanager.InsertManager;
+import org.dpppt.backend.sdk.ws.insertmanager.insertionfilters.AssertKeyFormat.KeyFormatException;
 import org.dpppt.backend.sdk.ws.security.ValidateRequest;
 import org.dpppt.backend.sdk.ws.security.ValidateRequest.ClaimIsBeforeOnsetException;
 import org.dpppt.backend.sdk.ws.security.ValidateRequest.InvalidDateException;
 import org.dpppt.backend.sdk.ws.security.ValidateRequest.WrongScopeException;
 import org.dpppt.backend.sdk.ws.security.signature.ProtoSignature;
-import org.dpppt.backend.sdk.ws.util.ValidationUtils;
 import org.dpppt.backend.sdk.ws.util.ValidationUtils.BadBatchReleaseTimeException;
+import org.dpppt.backend.sdk.ws.util.ValidationUtils.DelayedKeyDateClaimIsMissing;
+import org.dpppt.backend.sdk.ws.util.ValidationUtils.DelayedKeyDateIsInvalid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -32,13 +37,14 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.context.request.WebRequest;
 
 @Controller
 @RequestMapping("/v1/debug")
 public class DebugController {
   private final ValidateRequest validateRequest;
-  private final ValidationUtils validationUtils;
+  private final InsertManager insertManager;
   private final Duration releaseBucketDuration;
   private final Duration requestTime;
   private final ProtoSignature gaenSigner;
@@ -48,15 +54,15 @@ public class DebugController {
       DebugGAENDataService dataService,
       ProtoSignature gaenSigner,
       ValidateRequest validateRequest,
-      ValidationUtils validationUtils,
+      InsertManager insertManager,
       Duration releaseBucketDuration,
       Duration requestTime) {
     this.validateRequest = validateRequest;
-    this.validationUtils = validationUtils;
     this.releaseBucketDuration = releaseBucketDuration;
     this.requestTime = requestTime;
     this.gaenSigner = gaenSigner;
     this.dataService = dataService;
+    this.insertManager = insertManager;
   }
 
   @PostMapping(value = "/exposed")
@@ -65,32 +71,15 @@ public class DebugController {
       @RequestHeader(value = "User-Agent", required = true) String userAgent,
       @RequestHeader(value = "X-Device-Name", required = true) String deviceName,
       @AuthenticationPrincipal Object principal)
-      throws InvalidDateException, ClaimIsBeforeOnsetException, WrongScopeException {
+      throws InvalidDateException, ClaimIsBeforeOnsetException, WrongScopeException,
+          InsertException {
     var now = UTCInstant.now();
     this.validateRequest.isValid(principal);
 
-    List<GaenKey> nonFakeKeys = new ArrayList<>();
-    for (var key : gaenRequest.getGaenKeys()) {
-      if (!validationUtils.isValidKeyFormat(key.getKeyData())) {
-        return new ResponseEntity<>("No valid base64 key", HttpStatus.BAD_REQUEST);
-      }
-      this.validateRequest.validateKeyDate(now, principal, key);
-      if (this.validateRequest.isFakeRequest(principal, key)) {
-        continue;
-      } else {
-        nonFakeKeys.add(key);
-      }
-    }
-    if (principal instanceof Jwt
-        && ((Jwt) principal).containsClaim("fake")
-        && ((Jwt) principal).getClaim("fake").equals("1")
-        && !nonFakeKeys.isEmpty()) {
-      return ResponseEntity.badRequest().body("Claim is fake but list contains non fake keys");
-    }
-    if (!nonFakeKeys.isEmpty()) {
-      dataService.upsertExposees(deviceName, nonFakeKeys);
-    }
-
+    // Filter out non valid keys and insert them into the database (c.f. InsertManager and
+    // configured Filters in the WSBaseConfig)
+    insertManager.insertIntoDatabaseDEBUG(
+        deviceName, gaenRequest.getGaenKeys(), userAgent, principal, now);
     var responseBuilder = ResponseEntity.ok();
 
     normalizeRequestTime(now.getTimestamp());
@@ -104,13 +93,14 @@ public class DebugController {
           NoSuchAlgorithmException, SignatureException {
 
     var batchReleaseTimeDuration = Duration.ofMillis(batchReleaseTime);
+
     if (batchReleaseTime % releaseBucketDuration.toMillis() != 0) {
       return ResponseEntity.notFound().build();
     }
 
     var exposedKeys =
         dataService.getSortedExposedForBatchReleaseTime(
-            batchReleaseTimeDuration.toMillis(), releaseBucketDuration.toMillis());
+            UTCInstant.ofEpochMillis(batchReleaseTime), releaseBucketDuration);
 
     byte[] payload = gaenSigner.getPayload(exposedKeys);
 
@@ -149,5 +139,39 @@ public class DebugController {
     } catch (Exception ex) {
 
     }
+  }
+
+  @ExceptionHandler({DelayedKeyDateClaimIsMissing.class})
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  public ResponseEntity<String> delayedClaimIsWrong() {
+    return ResponseEntity.badRequest().body("DelayedKeyDateClaim is wrong");
+  }
+
+  @ExceptionHandler({DelayedKeyDateIsInvalid.class})
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  public ResponseEntity<String> delayedKeyDateIsInvalid() {
+    return ResponseEntity.badRequest()
+        .body("DelayedKeyDate must be between yesterday and tomorrow");
+  }
+
+  @ExceptionHandler({
+    IllegalArgumentException.class,
+    InvalidDateException.class,
+    JsonProcessingException.class,
+    MethodArgumentNotValidException.class,
+    BadBatchReleaseTimeException.class,
+    DateTimeParseException.class,
+    ClaimIsBeforeOnsetException.class,
+    KeyFormatException.class
+  })
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  public ResponseEntity<Object> invalidArguments() {
+    return ResponseEntity.badRequest().build();
+  }
+
+  @ExceptionHandler({WrongScopeException.class})
+  @ResponseStatus(HttpStatus.FORBIDDEN)
+  public ResponseEntity<Object> forbidden() {
+    return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
   }
 }

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/DebugController.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/controller/DebugController.java
@@ -22,8 +22,6 @@ import org.dpppt.backend.sdk.ws.security.ValidateRequest.InvalidDateException;
 import org.dpppt.backend.sdk.ws.security.ValidateRequest.WrongScopeException;
 import org.dpppt.backend.sdk.ws.security.signature.ProtoSignature;
 import org.dpppt.backend.sdk.ws.util.ValidationUtils.BadBatchReleaseTimeException;
-import org.dpppt.backend.sdk.ws.util.ValidationUtils.DelayedKeyDateClaimIsMissing;
-import org.dpppt.backend.sdk.ws.util.ValidationUtils.DelayedKeyDateIsInvalid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -71,8 +69,7 @@ public class DebugController {
       @RequestHeader(value = "User-Agent", required = true) String userAgent,
       @RequestHeader(value = "X-Device-Name", required = true) String deviceName,
       @AuthenticationPrincipal Object principal)
-      throws InvalidDateException, ClaimIsBeforeOnsetException, WrongScopeException,
-          InsertException {
+      throws WrongScopeException, InsertException {
     var now = UTCInstant.now();
     this.validateRequest.isValid(principal);
 
@@ -139,19 +136,6 @@ public class DebugController {
     } catch (Exception ex) {
 
     }
-  }
-
-  @ExceptionHandler({DelayedKeyDateClaimIsMissing.class})
-  @ResponseStatus(HttpStatus.BAD_REQUEST)
-  public ResponseEntity<String> delayedClaimIsWrong() {
-    return ResponseEntity.badRequest().body("DelayedKeyDateClaim is wrong");
-  }
-
-  @ExceptionHandler({DelayedKeyDateIsInvalid.class})
-  @ResponseStatus(HttpStatus.BAD_REQUEST)
-  public ResponseEntity<String> delayedKeyDateIsInvalid() {
-    return ResponseEntity.badRequest()
-        .body("DelayedKeyDate must be between yesterday and tomorrow");
   }
 
   @ExceptionHandler({

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/insertmanager/InsertManager.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/insertmanager/InsertManager.java
@@ -78,9 +78,7 @@ public class InsertManager {
     var internalKeys = filterAndModify(keys, header, principal, now);
     // if no keys remain or this is a fake request, just return. Else, insert the
     // remaining keys.
-    if (internalKeys.isEmpty() || validationUtils.jwtIsFake(principal)) {
-      return;
-    } else {
+    if (!internalKeys.isEmpty() && !validationUtils.jwtIsFake(principal)) {
       dataService.upsertExposees(internalKeys, now);
     }
   }
@@ -94,9 +92,7 @@ public class InsertManager {
     var internalKeys = filterAndModify(keys, header, principal, now);
     // if no keys remain or this is a fake request, just return. Else, insert the
     // remaining keys.
-    if (internalKeys.isEmpty() || validationUtils.jwtIsFake(principal)) {
-      return;
-    } else {
+    if (!internalKeys.isEmpty() && !validationUtils.jwtIsFake(principal)) {
       debugDataService.upsertExposees(deviceName, internalKeys);
     }
   }


### PR DESCRIPTION
Since the debug controller is used by the calibration app, we update the controller to also use the `InsertManager`. In order to allow certain debug only feature, a private constructor with a static instance getter function is added. The idea is, to prevent accidentally instantiating the wrong Manager. All functions, which are debug only are suffixed with `DEBUG` to help signalise a potentially error. 

If the debug instance of `InsertManager` is used with the __NON__debug function, a warning is printed. Furthermore the function will raise a NullPointerException when the wrong instance is used with the wrong function, to prevent any potential problems of mixing.

The debug instance of the `InsertManager` is only used in `WSProdConfig` and removes filters related to JWTs.

Closes: https://github.com/DP-3T/dp3t-sdk-backend/issues/242