### PR TITLE
add toString to UTCInstant

### DIFF
--- a/dpppt-backend-sdk/dpppt-backend-sdk-model/src/main/java/org/dpppt/backend/sdk/utils/UTCInstant.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-model/src/main/java/org/dpppt/backend/sdk/utils/UTCInstant.java
@@ -305,4 +305,9 @@ public class UTCInstant implements Closeable {
   public void close() throws IOException {
     UTCInstant.resetClock();
   }
+
+  /** @return the current instant as ISO-8601 string with millisecond precision */
+  public String toString() {
+    return this.getInstant().toString();
+  }
 }

--- a/dpppt-backend-sdk/dpppt-backend-sdk-model/src/test/java/org/dpppt/backend/sdk/utils/UTCInstantTest.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-model/src/test/java/org/dpppt/backend/sdk/utils/UTCInstantTest.java
@@ -3,6 +3,7 @@ package org.dpppt.backend.sdk.utils;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.Duration;
+import java.time.Instant;
 import org.junit.jupiter.api.Test;
 
 class UTCInstantTest {
@@ -39,5 +40,12 @@ class UTCInstantTest {
     bucket = Duration.ofMillis(99);
     assertTrue(keyTime.roundToNextBucket(bucket).equals(new UTCInstant((198))));
     assertTrue(keyTime.roundToBucketStart(bucket).equals(new UTCInstant((99))));
+  }
+
+  @Test
+  void toStringFmt() {
+    // Need to round Instant to milliseconds for correct comparison with UTCInstant.
+    var now = Instant.ofEpochMilli(Instant.now().toEpochMilli());
+    assertEquals(now.toString(), UTCInstant.ofEpochMillis(now.toEpochMilli()).toString());
   }
 }


### PR DESCRIPTION
This adds an ISO-8601 representation of the UTCInstant when using UTCInstant.toString()

Closes #253 