### PR TITLE
Shuffle keys for /v1/gaen/getExposed endpoint

### DIFF
--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/security/signature/ProtoSignature.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/security/signature/ProtoSignature.java
@@ -87,6 +87,10 @@ public class ProtoSignature {
     if (keys.isEmpty()) {
       throw new IOException("Keys should not be empty");
     }
+
+    // Shuffle the keys so that the clients don't know the order of arrival of the keys.
+    Collections.shuffle(keys);
+
     ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
     ZipOutputStream zip = new ZipOutputStream(byteOut);
     ByteArrayOutputStream hashOut = new ByteArrayOutputStream();
@@ -140,6 +144,7 @@ public class ProtoSignature {
     }
     // Apple likes to have keys shuffled. See
     // https://developer.apple.com/documentation/exposurenotification/setting_up_a_key_server
+    // This prevents the clients to know the order of arrival of the keys.
     Collections.shuffle(keys);
 
     ByteArrayOutputStream byteOut = new ByteArrayOutputStream();

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/controller/GaenControllerTest.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/controller/GaenControllerTest.java
@@ -36,6 +36,7 @@ import java.util.Map;
 import org.dpppt.backend.sdk.model.gaen.GaenKey;
 import org.dpppt.backend.sdk.model.gaen.GaenRequest;
 import org.dpppt.backend.sdk.model.gaen.GaenSecondDay;
+import org.dpppt.backend.sdk.model.gaen.proto.TemporaryExposureKeyFormat;
 import org.dpppt.backend.sdk.utils.UTCInstant;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -1102,6 +1103,46 @@ public class GaenControllerTest extends BaseControllerTest {
             .andReturn()
             .getResponse();
     verifyZipInZipResponse(response, 280, 144);
+  }
+
+  @Test
+  // Makes sure that two calls to /v1/gaen/exposed don't return the same set of keys.
+  public void testShuffle() throws Exception {
+    var now = UTCInstant.now();
+    var midnight = now.atStartOfDay().minusDays(1);
+    var nbrKeys = 100;
+
+    // Insert `nbrKeys - randomKeysPerDay` keys yesterday
+    insertNKeysPerDay(midnight, 1, nbrKeys - 10, midnight.minusDays(1), false);
+
+    // Request twice all keys and verify it's not the same order.
+    List<List<TemporaryExposureKeyFormat.TemporaryExposureKey>> responses = new ArrayList<>();
+    for (var i = 0; i < 2; i++) {
+      var keys =
+          getZipKeys(
+              mockMvc
+                  .perform(
+                      get("/v1/gaen/exposed/" + midnight.getTimestamp())
+                          .header("User-Agent", androidUserAgent))
+                  .andExpect(status().is2xxSuccessful())
+                  .andReturn()
+                  .getResponse());
+      responses.add(keys.getKeysList());
+    }
+    assertEquals(2, responses.size());
+    var keys0 = responses.get(0);
+    var keys1 = responses.get(1);
+    assertEquals(nbrKeys, keys0.size());
+    assertTrue(keys0.containsAll(keys1));
+
+    var same = 0;
+    for (var i = 0; i < keys0.size(); i++) {
+      // `startsWith` is used here to compare two keys, as `equals` always returns false.
+      if (keys0.get(i).getKeyData().startsWith(keys1.get(i).getKeyData())) {
+        same++;
+      }
+    }
+    assertNotEquals(nbrKeys, same);
   }
 
   @Test


### PR DESCRIPTION
Up to now for the /v1/gaen/getExposed endpoint, the order of the keys returned to the
clients has been the same as the order of submitting the keys. This reveals some
information that might be used to detect if somebody submitted a valid key or not.

Even if it's already fixed in /v2/gaen/exposed endpoint, this PR also shuffles
the keys for the /v1 endpoint.

Closes #274