### PR TITLE
Allow useragents that add more values.

### DIFF
--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/insertmanager/InsertManager.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/insertmanager/InsertManager.java
@@ -104,7 +104,7 @@ public class InsertManager {
     }
     var internalKeys = keys;
     var headerParts = header.split(";");
-    if (headerParts.length != 5) {
+    if (headerParts.length < 5) {
       headerParts =
           List.of("org.example.dp3t", "1.0.0", "0", "Android", "29").toArray(new String[0]);
       logger.error("We received an invalid header, setting default.");


### PR DESCRIPTION
Since the last Release, the Android app adds an additional value to the user agent string. This results in an error and sets the user agent back to a default value. 
This PR changes the check of the user agent value and allows the user agent to have more values. A mininum of 5 values must be set.