### PR TITLE
Update Spring Boot to 2.3.5. 

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -34,7 +34,6 @@ jobs:
     - name: Build with Maven
       run: |
         mvn install --file dpppt-backend-sdk/pom.xml; 
-        mvn springboot-swagger-3:springboot-swagger-3 -f dpppt-backend-sdk/dpppt-backend-sdk-ws/pom.xml
       env:
         GITHUB_TOKEN: ${{ github.token }}
         TESTCONTAINERS_RYUK_DISABLED: true

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -34,6 +34,7 @@ jobs:
     - name: Build with Maven
       run: |
         mvn install --file dpppt-backend-sdk/pom.xml; 
+        mvn springboot-swagger-3:springboot-swagger-3 -f dpppt-backend-sdk/dpppt-backend-sdk-ws/pom.xml
       env:
         GITHUB_TOKEN: ${{ github.token }}
         TESTCONTAINERS_RYUK_DISABLED: true

--- a/dpppt-backend-sdk/dpppt-backend-sdk-data/pom.xml
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-data/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.dpppt</groupId>
 		<artifactId>dpppt-backend-sdk</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
+		<version>${revision}</version>
 	</parent>
 	<artifactId>dpppt-backend-sdk-data</artifactId>
 	<name>DP3T Backend SDK Data</name>

--- a/dpppt-backend-sdk/dpppt-backend-sdk-data/pom.xml
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-data/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.dpppt</groupId>
 		<artifactId>dpppt-backend-sdk</artifactId>
-		<version>${revision}</version>
+		<version>2.0.2-SNAPSHOT</version>
 	</parent>
 	<artifactId>dpppt-backend-sdk-data</artifactId>
 	<name>DP3T Backend SDK Data</name>

--- a/dpppt-backend-sdk/dpppt-backend-sdk-model/pom.xml
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-model/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.dpppt</groupId>
 		<artifactId>dpppt-backend-sdk</artifactId>
-		<version>${revision}</version>
+		<version>2.0.2-SNAPSHOT</version>
 	</parent>
 	<artifactId>dpppt-backend-sdk-model</artifactId>
 	<name>DP3T Backend SDK Model</name>

--- a/dpppt-backend-sdk/dpppt-backend-sdk-model/pom.xml
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-model/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.dpppt</groupId>
 		<artifactId>dpppt-backend-sdk</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
+		<version>${revision}</version>
 	</parent>
 	<artifactId>dpppt-backend-sdk-model</artifactId>
 	<name>DP3T Backend SDK Model</name>

--- a/dpppt-backend-sdk/dpppt-backend-sdk-report/pom.xml
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-report/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.dpppt</groupId>
 		<artifactId>dpppt-backend-sdk</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
+		<version>${revision}</version>
 	</parent>
 	<artifactId>dpppt-backend-sdk-report</artifactId>
 	<name>DP3T Backend SDK Report</name>
@@ -32,19 +32,17 @@
 		<dependency>
 			<groupId>org.dpppt</groupId>
 			<artifactId>dpppt-backend-sdk-model</artifactId>
-			<version>1.0.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.dpppt</groupId>
 			<artifactId>dpppt-backend-sdk-data</artifactId>
-			<version>1.0.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.dpppt</groupId>
 			<artifactId>dpppt-backend-sdk-ws</artifactId>
-			<version>1.0.0-SNAPSHOT</version>
+			<version>${revision}</version>
 		</dependency>
 
 	</dependencies>

--- a/dpppt-backend-sdk/dpppt-backend-sdk-report/pom.xml
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-report/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.dpppt</groupId>
 		<artifactId>dpppt-backend-sdk</artifactId>
-		<version>${revision}</version>
+		<version>2.0.2-SNAPSHOT</version>
 	</parent>
 	<artifactId>dpppt-backend-sdk-report</artifactId>
 	<name>DP3T Backend SDK Report</name>
@@ -42,7 +42,7 @@
 		<dependency>
 			<groupId>org.dpppt</groupId>
 			<artifactId>dpppt-backend-sdk-ws</artifactId>
-			<version>${revision}</version>
+			<version>2.0.2-SNAPSHOT</version>
 		</dependency>
 
 	</dependencies>

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/pom.xml
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.dpppt</groupId>
 		<artifactId>dpppt-backend-sdk</artifactId>
-		<version>${revision}</version>
+		<version>2.0.2-SNAPSHOT</version>
 	</parent>
 	<artifactId>dpppt-backend-sdk-ws</artifactId>
 	<name>DP3T Backend SDK WS</name>

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/pom.xml
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.dpppt</groupId>
 		<artifactId>dpppt-backend-sdk</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
+		<version>${revision}</version>
 	</parent>
 	<artifactId>dpppt-backend-sdk-ws</artifactId>
 	<name>DP3T Backend SDK WS</name>
@@ -35,6 +35,12 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-cloud-connectors</artifactId>
+			<version>2.0.7.RELEASE</version>
+		</dependency>
+		
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
 
 		<dependency>

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/pom.xml
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/pom.xml
@@ -149,6 +149,7 @@
 					</ignoredTypes>
 					<controllers>
 						<controller>org.dpppt.backend.sdk.ws.controller.GaenController</controller>
+						<controller>org.dpppt.backend.sdk.ws.controller.GaenV2Controller</controller>
 					</controllers>
 					<description>DP3T API</description>
 					<apiUrls>

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/controller/GaenControllerTest.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/controller/GaenControllerTest.java
@@ -1292,7 +1292,7 @@ public class GaenControllerTest extends BaseControllerTest {
             .andExpect(status().is(401))
             .andReturn();
     String authenticateError = response.getResponse().getHeader("www-authenticate");
-    assertTrue(authenticateError.contains("Unsigned Claims JWTs are not supported."));
+    assertTrue(authenticateError.contains("Bearer"));
   }
 
   @Test

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/controller/GaenV2ControllerTest.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/controller/GaenV2ControllerTest.java
@@ -96,7 +96,7 @@ public class GaenV2ControllerTest extends BaseControllerTest {
             .andExpect(status().is(401))
             .andReturn();
     String authenticateError = response.getResponse().getHeader("www-authenticate");
-    assertTrue(authenticateError.contains("Unsigned Claims JWTs are not supported."));
+    assertTrue(authenticateError.contains("Bearer"));
   }
 
   @Test

--- a/dpppt-backend-sdk/pom.xml
+++ b/dpppt-backend-sdk/pom.xml
@@ -17,10 +17,12 @@
 	<groupId>org.dpppt</groupId>
 	<artifactId>dpppt-backend-sdk</artifactId>
 	<packaging>pom</packaging>
-	<version>1.0.0-SNAPSHOT</version>
+	<version>${revision}</version>
 	<name>DP3T Backend SDK</name>
 
 	<properties>
+		<revision>2.0.2-SNAPSHOT</revision>
+	
 		<java-version>11</java-version>
 
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -29,7 +31,7 @@
 		<jackson-version>2.11.1</jackson-version>
 		<jsonwebtoken-version>0.11.2</jsonwebtoken-version>
 		<protobuf-java-version>3.12.1</protobuf-java-version>
-		<spring-boot-version>2.2.10.RELEASE</spring-boot-version>
+		<spring-boot-version>2.3.5.RELEASE</spring-boot-version>
 		<testcontainers-version>1.15.0-rc2</testcontainers-version>
 
 		<itCoverageAgent></itCoverageAgent>

--- a/dpppt-backend-sdk/pom.xml
+++ b/dpppt-backend-sdk/pom.xml
@@ -17,12 +17,10 @@
 	<groupId>org.dpppt</groupId>
 	<artifactId>dpppt-backend-sdk</artifactId>
 	<packaging>pom</packaging>
-	<version>${revision}</version>
+	<version>2.0.2-SNAPSHOT</version>
 	<name>DP3T Backend SDK</name>
 
-	<properties>
-		<revision>2.0.2-SNAPSHOT</revision>
-	
+	<properties>	
 		<java-version>11</java-version>
 
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
* Update to Spring Boot 2.3.5
** Validation must be added since 2.3.x
** Adapt some unittests because of different behaviour in the 401 responses
** Fix version of cloud connectors, as project is in maintenance mode and will be replaced.
* Start clean versioning of our own artifacts