### PR TITLE
Remove unused path. Add path for v2

### DIFF
--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/config/MultipleJWTConfig.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/config/MultipleJWTConfig.java
@@ -148,7 +148,7 @@ public class MultipleJWTConfig {
           .cors()
           .and()
           .authorizeRequests()
-          .antMatchers(HttpMethod.POST, "/v1/exposed", "/v1/exposedlist", "/v1/gaen/exposed")
+          .antMatchers(HttpMethod.POST, "/v1/gaen/exposed", "/v2/gaen/exposed")
           .authenticated()
           .anyRequest()
           .permitAll()

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/controller/GaenV2ControllerTest.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/controller/GaenV2ControllerTest.java
@@ -79,6 +79,25 @@ public class GaenV2ControllerTest extends BaseControllerTest {
   }
 
   @Test
+  public void testNoTokenFails() throws Exception {
+    var requestList = new GaenRequest();
+    List<GaenKey> exposedKeys = new ArrayList<GaenKey>();
+    requestList.setGaenKeys(exposedKeys);
+    MvcResult response =
+        mockMvc
+            .perform(
+                post("/v2/gaen/exposed")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header("User-Agent", "MockMVC")
+                    .content(json(requestList)))
+            .andExpect(request().asyncNotStarted())
+            .andExpect(status().is(401))
+            .andReturn();
+    String authenticateError = response.getResponse().getHeader("www-authenticate");
+    assertTrue(authenticateError.contains("Bearer"));
+  }
+
+  @Test
   public void testMalciousTokenFails() throws Exception {
     var requestList = new GaenRequest();
     List<GaenKey> exposedKeys = new ArrayList<GaenKey>();


### PR DESCRIPTION
* Cleanup unused paths
* Add path for v2: due to the design of the current architecture, jwt tokens are strictly needed and there was no impact on leaving this path out. Suppling no jwt to the request ended in an validation error in the controller. adding a jwt token via authorzation header automatically invoked the authorization chain and required the jwt tokens to be properly signed.