### PR TITLE
Backport Key Retrieval to V1

### DIFF
--- a/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/gaen/JDBCGAENDataServiceImpl.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/gaen/JDBCGAENDataServiceImpl.java
@@ -101,7 +101,7 @@ public class JDBCGAENDataServiceImpl implements GAENDataService {
     String sql =
         "select pk_exposed_id, key, rolling_start_number, rolling_period, transmission_risk_level"
             + " from t_gaen_exposed where rolling_start_number >= :rollingPeriodStartNumberStart"
-            + " and rolling_start_number < :rollingPeriodStartNumberEnd and received_at <"
+            + " and rolling_start_number < :rollingPeriodStartNumberEnd and max(received_at, rolling_start_number + rolling_period + timeSkew) <"
             + " :publishedUntil";
     // we need to subtract the time skew since we want to release it iff rolling_start_number +
     // rolling_period + timeSkew < NOW
@@ -112,7 +112,7 @@ public class JDBCGAENDataServiceImpl implements GAENDataService {
     params.addValue(
         "maxAllowedStartNumber",
         now.roundToBucketStart(releaseBucketDuration).minus(timeSkew).get10MinutesSince1970());
-    sql += " and rolling_start_number + rolling_period < :maxAllowedStartNumber";
+    sql += " and rolling_start_number + rolling_period + timeSkew < :maxAllowedStartNumber";
 
     // note that received_at is always rounded to `next_bucket` - 1ms to difuse actual upload time
     if (publishedAfter != null) {

--- a/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/gaen/JDBCGAENDataServiceImpl.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/gaen/JDBCGAENDataServiceImpl.java
@@ -101,7 +101,7 @@ public class JDBCGAENDataServiceImpl implements GAENDataService {
     String sql =
         "select pk_exposed_id, key, rolling_start_number, rolling_period, transmission_risk_level"
             + " from t_gaen_exposed where rolling_start_number >= :rollingPeriodStartNumberStart"
-            + " and rolling_start_number < :rollingPeriodStartNumberEnd and max(received_at, rolling_start_number + rolling_period + timeSkew) <"
+            + " and rolling_start_number < :rollingPeriodStartNumberEnd and received_at <"
             + " :publishedUntil";
     // we need to subtract the time skew since we want to release it iff rolling_start_number +
     // rolling_period + timeSkew < NOW
@@ -112,7 +112,7 @@ public class JDBCGAENDataServiceImpl implements GAENDataService {
     params.addValue(
         "maxAllowedStartNumber",
         now.roundToBucketStart(releaseBucketDuration).minus(timeSkew).get10MinutesSince1970());
-    sql += " and rolling_start_number + rolling_period + timeSkew < :maxAllowedStartNumber";
+    sql += " and rolling_start_number + rolling_period < :maxAllowedStartNumber";
 
     // note that received_at is always rounded to `next_bucket` - 1ms to difuse actual upload time
     if (publishedAfter != null) {

--- a/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/gaen/JDBCGAENDataServiceImpl.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-data/src/main/java/org/dpppt/backend/sdk/data/gaen/JDBCGAENDataServiceImpl.java
@@ -93,19 +93,20 @@ public class JDBCGAENDataServiceImpl implements GAENDataService {
   @Transactional(readOnly = true)
   public List<GaenKey> getSortedExposedForKeyDate(
       UTCInstant keyDate, UTCInstant publishedAfter, UTCInstant publishedUntil, UTCInstant now) {
-    return getKeys(publishedAfter, now, keyDate);
+    return getKeys(publishedAfter, now, keyDate, publishedUntil);
   }
 
   @Override
   @Transactional(readOnly = true)
   public List<GaenKey> getSortedExposedSince(UTCInstant keysSince, UTCInstant now) {
-    return getKeys(keysSince, now, null);
+    return getKeys(keysSince, now, null, now.roundToBucketStart(releaseBucketDuration));
   }
 
-  private List<GaenKey> getKeys(UTCInstant keysSince, UTCInstant now, UTCInstant keyDate) {
+  private List<GaenKey> getKeys(
+      UTCInstant keysSince, UTCInstant now, UTCInstant keyDate, UTCInstant maxBucket) {
     MapSqlParameterSource params = new MapSqlParameterSource();
     params.addValue("since", keysSince.getDate());
-    params.addValue("maxBucket", now.roundToBucketStart(releaseBucketDuration).getDate());
+    params.addValue("maxBucket", maxBucket.getDate());
     params.addValue("timeSkewSeconds", timeSkew.toSeconds());
 
     // Select keys since the given date. We need to make sure, only keys are returned

--- a/dpppt-backend-sdk/dpppt-backend-sdk-data/src/test/java/org/dpppt/backend/sdk/data/gaen/PostgresGaenDataServiceTest.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-data/src/test/java/org/dpppt/backend/sdk/data/gaen/PostgresGaenDataServiceTest.java
@@ -77,11 +77,12 @@ public class PostgresGaenDataServiceTest {
       var keysUntilToday = today.minusDays(21);
 
       var keys = new ArrayList<GaenKey>();
-      var emptyList = fakeKeyService.fillUpKeys(keys, null, noKeyAtThisDate, now);
+      var emptyList =
+          fakeKeyService.fillUpKeys(keys, UTCInstant.midnight1970(), noKeyAtThisDate, now);
       assertEquals(0, emptyList.size());
       do {
         keys.clear();
-        var list = fakeKeyService.fillUpKeys(keys, null, keysUntilToday, now);
+        var list = fakeKeyService.fillUpKeys(keys, UTCInstant.midnight1970(), keysUntilToday, now);
 
         assertEquals(10, list.size());
         list = fakeKeyService.fillUpKeys(keys, UTCInstant.now().plusHours(3), keysUntilToday, now);
@@ -90,7 +91,7 @@ public class PostgresGaenDataServiceTest {
       } while (keysUntilToday.isBeforeDateOf(today));
 
       keys.clear();
-      emptyList = fakeKeyService.fillUpKeys(keys, null, noKeyAtThisDate, now);
+      emptyList = fakeKeyService.fillUpKeys(keys, UTCInstant.midnight1970(), noKeyAtThisDate, now);
       assertEquals(0, emptyList.size());
     }
   }
@@ -150,13 +151,15 @@ public class PostgresGaenDataServiceTest {
         receivedAt.getInstant(), receivedAt.minusDays(1).getInstant(), key);
 
     List<GaenKey> sortedExposedForDay =
-        gaenDataService.getSortedExposedForKeyDate(receivedAt.minusDays(1), null, now, now);
+        gaenDataService.getSortedExposedForKeyDate(
+            receivedAt.minusDays(1), UTCInstant.midnight1970(), now, now);
 
     assertFalse(sortedExposedForDay.isEmpty());
 
     gaenDataService.cleanDB(Duration.ofDays(21));
     sortedExposedForDay =
-        gaenDataService.getSortedExposedForKeyDate(receivedAt.minusDays(1), null, now, now);
+        gaenDataService.getSortedExposedForKeyDate(
+            receivedAt.minusDays(1), UTCInstant.midnight1970(), now, now);
 
     assertTrue(sortedExposedForDay.isEmpty());
   }
@@ -181,7 +184,10 @@ public class PostgresGaenDataServiceTest {
 
     var returnedKeys =
         gaenDataService.getSortedExposedForKeyDate(
-            UTCInstant.today().minus(Duration.ofDays(1)), null, publishedUntil, now);
+            UTCInstant.today().minus(Duration.ofDays(1)),
+            UTCInstant.midnight1970(),
+            publishedUntil,
+            now);
 
     assertEquals(keys.size(), returnedKeys.size());
     assertEquals(keys.get(0).getKeyData(), returnedKeys.get(0).getKeyData());
@@ -199,7 +205,7 @@ public class PostgresGaenDataServiceTest {
 
     var returnedKeys =
         gaenDataService.getSortedExposedForKeyDate(
-            receivedAt.minus(Duration.ofDays(2)), null, batchTime, now);
+            receivedAt.minus(Duration.ofDays(2)), UTCInstant.midnight1970(), batchTime, now);
 
     assertEquals(1, returnedKeys.size());
     GaenKey actual = returnedKeys.get(0);

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/config/WSBaseConfig.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/java/org/dpppt/backend/sdk/ws/config/WSBaseConfig.java
@@ -293,7 +293,8 @@ public abstract class WSBaseConfig implements SchedulingConfigurer, WebMvcConfig
         Duration.ofMillis(releaseBucketDuration),
         Duration.ofMillis(requestTime),
         Duration.ofMillis(exposedListCacheControl),
-        keyVault.get("nextDayJWT").getPrivate());
+        keyVault.get("nextDayJWT").getPrivate(),
+        Duration.ofDays(retentionDays));
   }
 
   @Bean

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/controller/BaseControllerTest.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/controller/BaseControllerTest.java
@@ -292,7 +292,7 @@ public abstract class BaseControllerTest {
     var result =
         gaenDataService.getSortedExposedForKeyDate(
             now.atStartOfDay().minusDays(1),
-            null,
+            UTCInstant.midnight1970(),
             now.roundToNextBucket(releaseBucketDuration),
             now);
     assertEquals(2, result.size());
@@ -303,7 +303,7 @@ public abstract class BaseControllerTest {
     result =
         gaenDataService.getSortedExposedForKeyDate(
             now.atStartOfDay().minusDays(1),
-            null,
+            UTCInstant.midnight1970(),
             now.roundToBucketStart(releaseBucketDuration),
             now);
     assertEquals(0, result.size());
@@ -313,19 +313,22 @@ public abstract class BaseControllerTest {
     result =
         gaenDataService.getSortedExposedForKeyDate(
             now.atStartOfDay(),
-            null,
+            UTCInstant.midnight1970(),
             tomorrow2AM.roundToNextBucket(releaseBucketDuration),
             tomorrow2AM);
     assertEquals(1, result.size());
 
     result =
         gaenDataService.getSortedExposedForKeyDate(
-            now.atStartOfDay(), null, now.roundToNextBucket(releaseBucketDuration), now);
+            now.atStartOfDay(),
+            UTCInstant.midnight1970(),
+            now.roundToNextBucket(releaseBucketDuration),
+            now);
     assertEquals(0, result.size());
 
     result =
         gaenDataService.getSortedExposedForKeyDate(
-            now.atStartOfDay(), null, now.atStartOfDay().plusDays(1), now);
+            now.atStartOfDay(), UTCInstant.midnight1970(), now.atStartOfDay().plusDays(1), now);
     assertEquals(0, result.size());
   }
 

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/controller/GaenControllerTest.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/controller/GaenControllerTest.java
@@ -1312,7 +1312,7 @@ public class GaenControllerTest extends BaseControllerTest {
   }
 
   @Test
-  public void testUploadTodaysKeyWillBeReleasedTomorrow() throws Exception {
+  public void testUploadWithShortenedRollingPeriod() throws Exception {
 
     int rollingPeriod = 84;
     var now = UTCInstant.now().atStartOfDay().plusHours(13).plusMinutes(55);

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/controller/GaenControllerTest.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/controller/GaenControllerTest.java
@@ -178,11 +178,15 @@ public class GaenControllerTest extends BaseControllerTest {
 
     var result =
         gaenDataService.getSortedExposedForKeyDate(
-            midnight.minusDays(1), null, now.roundToNextBucket(releaseBucketDuration), now);
+            midnight.minusDays(1),
+            UTCInstant.midnight1970(),
+            now.roundToNextBucket(releaseBucketDuration),
+            now);
     // all keys are invalid
     assertEquals(0, result.size());
   }
 
+  @Test
   @Transactional
   public void testMultipleKeyUpload() throws Exception {
     testNKeys(UTCInstant.now(), 14, true);
@@ -278,12 +282,15 @@ public class GaenControllerTest extends BaseControllerTest {
 
     var result =
         gaenDataService.getSortedExposedForKeyDate(
-            midnight.minusDays(1), null, now.roundToNextBucket(releaseBucketDuration), now);
+            midnight.minusDays(1),
+            UTCInstant.midnight1970(),
+            now.roundToNextBucket(releaseBucketDuration),
+            now);
     // all keys are invalid
     assertEquals(0, result.size());
     result =
         gaenDataService.getSortedExposedForKeyDate(
-            midnight, null, now.roundToNextBucket(releaseBucketDuration), now);
+            midnight, UTCInstant.midnight1970(), now.roundToNextBucket(releaseBucketDuration), now);
     // all keys are invalid
     assertEquals(0, result.size());
   }
@@ -645,7 +652,10 @@ public class GaenControllerTest extends BaseControllerTest {
             .andReturn();
     var result =
         gaenDataService.getSortedExposedForKeyDate(
-            midnight.minusDays(2), null, now.roundToNextBucket(releaseBucketDuration), now);
+            midnight.minusDays(2),
+            UTCInstant.midnight1970(),
+            now.roundToNextBucket(releaseBucketDuration),
+            now);
 
     assertEquals(0, result.size());
   }
@@ -736,7 +746,10 @@ public class GaenControllerTest extends BaseControllerTest {
             .andReturn();
     var result =
         gaenDataService.getSortedExposedForKeyDate(
-            midnight.plusDays(2), null, now.roundToNextBucket(releaseBucketDuration), now);
+            midnight.plusDays(2),
+            UTCInstant.midnight1970(),
+            now.roundToNextBucket(releaseBucketDuration),
+            now);
 
     assertEquals(0, result.size());
   }
@@ -784,7 +797,10 @@ public class GaenControllerTest extends BaseControllerTest {
             .andReturn();
     var result =
         gaenDataService.getSortedExposedForKeyDate(
-            midnight.minusDays(22), null, now.roundToNextBucket(releaseBucketDuration), now);
+            midnight.minusDays(22),
+            UTCInstant.midnight1970(),
+            now.roundToNextBucket(releaseBucketDuration),
+            now);
     assertEquals(0, result.size());
   }
 
@@ -1367,7 +1383,11 @@ public class GaenControllerTest extends BaseControllerTest {
       publishedUntil = response.getHeader("x-published-until");
     }
 
-    logger.debug("Critical publishedUntil is "+publishedUntil+" at request time "+fourHoursLater.toString());
+    logger.debug(
+        "Critical publishedUntil is "
+            + publishedUntil
+            + " at request time "
+            + fourHoursLater.toString());
 
     Clock eightHoursLater = Clock.fixed(now.plusHours(8).getInstant(), ZoneOffset.UTC);
 

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/controller/GaenControllerTest.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/controller/GaenControllerTest.java
@@ -1297,7 +1297,14 @@ public class GaenControllerTest extends BaseControllerTest {
 
   @Test
   public void testUploadTodaysKeyWillBeReleasedTomorrow() throws Exception {
-    var now = UTCInstant.now();
+
+    int rollingPeriod = 84;
+    var now = UTCInstant.now().atStartOfDay().plusHours(13).plusMinutes(55);
+
+    String publishedUntil = null;
+
+    logger.debug("Testing RollingPeriod " + rollingPeriod);
+
     GaenRequest exposeeRequest = new GaenRequest();
     List<GaenKey> keys = new ArrayList<>();
     for (int i = 0; i < 30; i++) {
@@ -1305,7 +1312,7 @@ public class GaenControllerTest extends BaseControllerTest {
       tmpKey.setRollingStartNumber((int) now.atStartOfDay().minusDays(i).get10MinutesSince1970());
       var keyData = String.format("testKey32Bytes%02d", i);
       tmpKey.setKeyData(Base64.getEncoder().encodeToString(keyData.getBytes("UTF-8")));
-      tmpKey.setRollingPeriod(144);
+      tmpKey.setRollingPeriod(rollingPeriod);
       tmpKey.setFake(0);
       tmpKey.setTransmissionRiskLevel(0);
       keys.add(tmpKey);
@@ -1315,43 +1322,71 @@ public class GaenControllerTest extends BaseControllerTest {
     var delayedKeyDateSent = (int) now.atStartOfDay().get10MinutesSince1970();
     exposeeRequest.setDelayedKeyDate(delayedKeyDateSent);
 
-    String token = createToken(now.plusMinutes(5));
-    MvcResult responseAsync =
-        mockMvc
-            .perform(
-                post("/v1/gaen/exposed")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .header("Authorization", "Bearer " + token)
-                    .header("User-Agent", androidUserAgent)
-                    .content(json(exposeeRequest)))
-            .andExpect(request().asyncStarted())
-            .andReturn();
-    mockMvc.perform(asyncDispatch(responseAsync)).andExpect(status().isOk());
+    String token = createToken(UTCInstant.now().plusMinutes(5));
 
-    var tooEarlyInstant = now.atStartOfDay();
-    MockHttpServletResponse response =
-        mockMvc
-            .perform(
-                get("/v1/gaen/exposed/" + tooEarlyInstant.getTimestamp())
-                    .header("User-Agent", androidUserAgent))
-            .andExpect(status().is(204))
-            .andReturn()
-            .getResponse();
+    try (var timeLock = UTCInstant.setClock(Clock.fixed(now.getInstant(), ZoneOffset.UTC))) {
+      MvcResult responseAsync =
+          mockMvc
+              .perform(
+                  post("/v1/gaen/exposed")
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .header("Authorization", "Bearer " + token)
+                      .header("User-Agent", androidUserAgent)
+                      .content(json(exposeeRequest)))
+              .andExpect(request().asyncStarted())
+              .andReturn();
+      mockMvc.perform(asyncDispatch(responseAsync)).andExpect(status().isOk());
 
-    Clock fourAMTomorrow =
-        Clock.fixed(now.atStartOfDay().plusDays(1).plusHours(4).getInstant(), ZoneOffset.UTC);
-
-    try (var timeLock = UTCInstant.setClock(fourAMTomorrow)) {
-      response =
+      var tooEarlyInstant = now.atStartOfDay();
+      MockHttpServletResponse response =
           mockMvc
               .perform(
                   get("/v1/gaen/exposed/" + tooEarlyInstant.getTimestamp())
                       .header("User-Agent", androidUserAgent))
+              .andExpect(status().is(204))
+              .andReturn()
+              .getResponse();
+
+      publishedUntil = response.getHeader("x-published-until");
+    }
+
+    Clock fourHoursLater = Clock.fixed(now.plusHours(4).getInstant(), ZoneOffset.UTC);
+
+    try (var timeLock = UTCInstant.setClock(fourHoursLater)) {
+      MockHttpServletResponse response =
+          mockMvc
+              .perform(
+                  get("/v1/gaen/exposed/"
+                          + now.atStartOfDay().getTimestamp()
+                          + "?publishedafter="
+                          + publishedUntil)
+                      .header("User-Agent", androidUserAgent))
+              .andExpect(status().is(204))
+              .andReturn()
+              .getResponse();
+      publishedUntil = response.getHeader("x-published-until");
+    }
+
+    logger.debug("Critical publishedUntil is "+publishedUntil+" at request time "+fourHoursLater.toString());
+
+    Clock eightHoursLater = Clock.fixed(now.plusHours(8).getInstant(), ZoneOffset.UTC);
+
+    try (var timeLock = UTCInstant.setClock(eightHoursLater)) {
+      MockHttpServletResponse response =
+          mockMvc
+              .perform(
+                  get("/v1/gaen/exposed/"
+                          + now.atStartOfDay().getTimestamp()
+                          + "?publishedafter="
+                          + publishedUntil)
+                      .header("User-Agent", androidUserAgent))
               .andExpect(status().isOk())
               .andReturn()
               .getResponse();
-      verifyZipResponse(response, 1, 144);
+      verifyZipResponse(response, 1, rollingPeriod);
     }
+
+    testGaenDataService.clear();
   }
 
   /**

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/util/TestJDBCGaen.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/util/TestJDBCGaen.java
@@ -11,6 +11,7 @@ package org.dpppt.backend.sdk.ws.util;
 
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import javax.sql.DataSource;
 import org.dpppt.backend.sdk.data.gaen.GaenKeyRowMapper;
@@ -120,5 +121,10 @@ public class TestJDBCGaen {
       parameterList.add(params);
     }
     jt.batchUpdate(sql, parameterList.toArray(new MapSqlParameterSource[0]));
+  }
+
+  public void clear(){
+    jt.update("DELETE FROM t_gaen_exposed;", new HashMap<>());
+    jt.update("DELETE FROM t_debug_gaen_exposed;", new HashMap<>());
   }
 }

--- a/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/util/TestJDBCGaen.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-ws/src/test/java/org/dpppt/backend/sdk/ws/util/TestJDBCGaen.java
@@ -123,7 +123,7 @@ public class TestJDBCGaen {
     jt.batchUpdate(sql, parameterList.toArray(new MapSqlParameterSource[0]));
   }
 
-  public void clear(){
+  public void clear() {
     jt.update("DELETE FROM t_gaen_exposed;", new HashMap<>());
     jt.update("DELETE FROM t_debug_gaen_exposed;", new HashMap<>());
   }


### PR DESCRIPTION
Due to a bug found in the retrieval of keys in certain circumstances on the v1 gaen API we backport the new sql logic how to retrieve keys from v2 to v1. This has the advantage, that we only have to maintain 1 sql query for v1 and v2.