### PR TITLE
Fix detection of issue

### DIFF
--- a/.github/workflows/close_issue.yaml
+++ b/.github/workflows/close_issue.yaml
@@ -28,7 +28,7 @@ jobs:
             const body = pr.body;
             const lines = body.split('\n').map((l)=>l.trim());
             const closers = new RegExp(
-              /(close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)/i);
+              /^(close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved) .*#/i);
             const issues = lines.filter((l)=>l.match(closers));
             const issue_nbrs = issues.map((i) => i.replace(/.*#/, ''));
             issue_nbrs.forEach((i) => {


### PR DESCRIPTION
The original script searched for the keywords in any place. But GitHub insists that the keywords are at the beginning of a line. Also, there needs to be a `#` after the keyword.

Testing: Closing
Close 1234
Closes #293