### PR TITLE
EFGS: Add tests and fix calculation of (calendar) days since submission

### DIFF
--- a/dpppt-backend-sdk/dpppt-backend-sdk-interops/src/main/java/org/dpppt/backend/sdk/interops/syncer/efgs/EfgsClient.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-interops/src/main/java/org/dpppt/backend/sdk/interops/syncer/efgs/EfgsClient.java
@@ -10,14 +10,14 @@
 
 package org.dpppt.backend.sdk.interops.syncer.efgs;
 
+import static org.dpppt.backend.sdk.utils.EfgsDsosUtil.calculateDefaultDsosMapping;
+
 import com.google.protobuf.ByteString;
 import java.io.IOException;
 import java.net.URI;
 import java.security.GeneralSecurityException;
 import java.security.cert.CertificateException;
-import java.time.Duration;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Base64;
@@ -33,12 +33,10 @@ import org.dpppt.backend.sdk.interops.syncer.efgs.signing.CryptoProvider;
 import org.dpppt.backend.sdk.interops.utils.RestTemplateHelper;
 import org.dpppt.backend.sdk.model.gaen.GaenKey;
 import org.dpppt.backend.sdk.model.gaen.GaenKeyForInterops;
-import org.dpppt.backend.sdk.model.gaen.GaenUnit;
 import org.dpppt.backend.sdk.model.gaen.ReportType;
 import org.dpppt.backend.sdk.model.interops.proto.EfgsProto;
 import org.dpppt.backend.sdk.model.interops.proto.EfgsProto.DiagnosisKey;
 import org.dpppt.backend.sdk.model.interops.proto.EfgsProto.DiagnosisKeyBatch;
-import org.dpppt.backend.sdk.utils.UTCInstant;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
@@ -229,15 +227,8 @@ public class EfgsClient {
         .setDaysSinceOnsetOfSymptoms(
             gaenKey.getDaysSinceOnsetOfSymptoms() != null
                 ? gaenKey.getDaysSinceOnsetOfSymptoms()
-                : calculateDsos(gaenKey))
+                : calculateDefaultDsosMapping(gaenKey))
         .build();
-  }
-
-  private int calculateDsos(GaenKeyForInterops gaenKey) {
-    LocalDateTime rollingStartNumber =
-        UTCInstant.of(gaenKey.getRollingStartNumber(), GaenUnit.TenMinutes).getLocalDateTime();
-    LocalDateTime receivedAt = gaenKey.getReceivedAt().getLocalDateTime();
-    return (int) Duration.between(receivedAt, rollingStartNumber).toDays() + 2000;
   }
 
   private List<GaenKeyForInterops> mapToGaenKeyForInteropsList(

--- a/dpppt-backend-sdk/dpppt-backend-sdk-model/src/main/java/org/dpppt/backend/sdk/utils/EfgsDsosUtil.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-model/src/main/java/org/dpppt/backend/sdk/utils/EfgsDsosUtil.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2021 Ubique Innovation AG <https://www.ubique.ch>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+
+package org.dpppt.backend.sdk.utils;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import org.dpppt.backend.sdk.model.gaen.GaenKeyForInterops;
+import org.dpppt.backend.sdk.model.gaen.GaenUnit;
+
+public class EfgsDsosUtil {
+
+  public static int calculateDefaultDsosMapping(GaenKeyForInterops gaenKey) {
+    LocalDateTime rollingStartNumber =
+        UTCInstant.of(gaenKey.getRollingStartNumber(), GaenUnit.TenMinutes).getLocalDateTime();
+    LocalDateTime receivedAt = gaenKey.getReceivedAt().getLocalDateTime();
+    return (int) Duration.between(receivedAt, rollingStartNumber).toDays() + 2000;
+  }
+
+}

--- a/dpppt-backend-sdk/dpppt-backend-sdk-model/src/main/java/org/dpppt/backend/sdk/utils/EfgsDsosUtil.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-model/src/main/java/org/dpppt/backend/sdk/utils/EfgsDsosUtil.java
@@ -8,11 +8,10 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-
 package org.dpppt.backend.sdk.utils;
 
-import java.time.Duration;
 import java.time.LocalDateTime;
+import java.time.Period;
 import org.dpppt.backend.sdk.model.gaen.GaenKeyForInterops;
 import org.dpppt.backend.sdk.model.gaen.GaenUnit;
 
@@ -22,7 +21,9 @@ public class EfgsDsosUtil {
     LocalDateTime rollingStartNumber =
         UTCInstant.of(gaenKey.getRollingStartNumber(), GaenUnit.TenMinutes).getLocalDateTime();
     LocalDateTime receivedAt = gaenKey.getReceivedAt().getLocalDateTime();
-    return (int) Duration.between(receivedAt, rollingStartNumber).toDays() + 2000;
-  }
 
+    int daysSinceSubmission =
+        Period.between(receivedAt.toLocalDate(), rollingStartNumber.toLocalDate()).getDays();
+    return daysSinceSubmission + 2000;
+  }
 }

--- a/dpppt-backend-sdk/dpppt-backend-sdk-model/src/main/java/org/dpppt/backend/sdk/utils/EfgsDsosUtil.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-model/src/main/java/org/dpppt/backend/sdk/utils/EfgsDsosUtil.java
@@ -17,6 +17,10 @@ import org.dpppt.backend.sdk.model.gaen.GaenUnit;
 
 public class EfgsDsosUtil {
 
+  public static int DSOS_SYMPTOMATIC_UNKNOWN_ONSET_ZERO_POINT = 2000;
+  public static int DSOS_ASYMPTOMATIC_ZERO_POINT = 3000;
+  public static int DSOS_UNKNOWN_SYMPTOM_STATUS_ZERO_POINT = 2000;
+
   public static int calculateDefaultDsosMapping(GaenKeyForInterops gaenKey) {
     LocalDateTime rollingStartNumber =
         UTCInstant.of(gaenKey.getRollingStartNumber(), GaenUnit.TenMinutes).getLocalDateTime();
@@ -24,6 +28,6 @@ public class EfgsDsosUtil {
 
     int daysSinceSubmission =
         Period.between(receivedAt.toLocalDate(), rollingStartNumber.toLocalDate()).getDays();
-    return daysSinceSubmission + 2000;
+    return DSOS_SYMPTOMATIC_UNKNOWN_ONSET_ZERO_POINT + daysSinceSubmission;
   }
 }

--- a/dpppt-backend-sdk/dpppt-backend-sdk-model/src/test/java/org/dpppt/backend/sdk/utils/EfgsDsosUtilTest.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-model/src/test/java/org/dpppt/backend/sdk/utils/EfgsDsosUtilTest.java
@@ -1,0 +1,48 @@
+package org.dpppt.backend.sdk.utils;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.time.Clock;
+import java.time.ZoneOffset;
+import org.dpppt.backend.sdk.model.gaen.GaenKey;
+import org.dpppt.backend.sdk.model.gaen.GaenKeyForInterops;
+import org.junit.jupiter.api.Test;
+
+public class EfgsDsosUtilTest {
+  @Test
+  void testDsosMapping(){
+    var now = UTCInstant.now();
+
+    testWithSubmissionTime(now.atStartOfDay().plusHours(1));
+    testWithSubmissionTime(now.atStartOfDay().plusHours(14));
+    testWithSubmissionTime(now.atStartOfDay().plusHours(23));
+  }
+
+  void testWithSubmissionTime(UTCInstant submissionTime) {
+
+    GaenKeyForInterops submissionDateKey = new GaenKeyForInterops();
+    submissionDateKey.setGaenKey(new GaenKey());
+    submissionDateKey.setReceivedAt(submissionTime);
+    submissionDateKey.setRollingStartNumber(
+        (int) submissionTime.atStartOfDay().get10MinutesSince1970());
+
+    assertEquals(2000, EfgsDsosUtil.calculateDefaultDsosMapping(submissionDateKey));
+
+    GaenKeyForInterops submissionPlus3Key = new GaenKeyForInterops();
+    submissionPlus3Key.setGaenKey(new GaenKey());
+    submissionPlus3Key.setReceivedAt(submissionTime);
+    submissionPlus3Key.setRollingStartNumber(
+        (int) submissionTime.plusDays(3).atStartOfDay().get10MinutesSince1970());
+
+    assertEquals(2000 + 3, EfgsDsosUtil.calculateDefaultDsosMapping(submissionPlus3Key));
+
+    GaenKeyForInterops submissionMinus10Key = new GaenKeyForInterops();
+    submissionMinus10Key.setGaenKey(new GaenKey());
+    submissionMinus10Key.setReceivedAt(submissionTime);
+    submissionMinus10Key.setRollingStartNumber(
+        (int) submissionTime.minusDays(10).atStartOfDay().get10MinutesSince1970());
+
+    assertEquals(2000 - 10, EfgsDsosUtil.calculateDefaultDsosMapping(submissionMinus10Key));
+  }
+}

--- a/dpppt-backend-sdk/dpppt-backend-sdk-model/src/test/java/org/dpppt/backend/sdk/utils/EfgsDsosUtilTest.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-model/src/test/java/org/dpppt/backend/sdk/utils/EfgsDsosUtilTest.java
@@ -25,6 +25,7 @@ public class EfgsDsosUtilTest {
     submissionDateKey.setRollingStartNumber(
         (int) submissionTime.atStartOfDay().get10MinutesSince1970());
 
+    // GaenKey of submission day has to have symptomatic unknown onset zero point (2000)
     assertEquals(
         DSOS_SYMPTOMATIC_UNKNOWN_ONSET_ZERO_POINT,
         EfgsDsosUtil.calculateDefaultDsosMapping(submissionDateKey));
@@ -35,6 +36,8 @@ public class EfgsDsosUtilTest {
     submissionPlus3Key.setRollingStartNumber(
         (int) submissionTime.plusDays(3).atStartOfDay().get10MinutesSince1970());
 
+    // GaenKey of 3 calendar days after submission has to have
+    // symptomatic unknown onset zero point + 3 (2003)
     assertEquals(
         DSOS_SYMPTOMATIC_UNKNOWN_ONSET_ZERO_POINT + 3,
         EfgsDsosUtil.calculateDefaultDsosMapping(submissionPlus3Key));
@@ -45,6 +48,8 @@ public class EfgsDsosUtilTest {
     submissionMinus10Key.setRollingStartNumber(
         (int) submissionTime.minusDays(10).atStartOfDay().get10MinutesSince1970());
 
+    // GaenKey of 10 calendar days before submission has to have
+    // symptomatic unknown onset zero point - 10 (1990)
     assertEquals(
         DSOS_SYMPTOMATIC_UNKNOWN_ONSET_ZERO_POINT - 10,
         EfgsDsosUtil.calculateDefaultDsosMapping(submissionMinus10Key));

--- a/dpppt-backend-sdk/dpppt-backend-sdk-model/src/test/java/org/dpppt/backend/sdk/utils/EfgsDsosUtilTest.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-model/src/test/java/org/dpppt/backend/sdk/utils/EfgsDsosUtilTest.java
@@ -3,16 +3,13 @@ package org.dpppt.backend.sdk.utils;
 import static org.dpppt.backend.sdk.utils.EfgsDsosUtil.DSOS_SYMPTOMATIC_UNKNOWN_ONSET_ZERO_POINT;
 import static org.junit.Assert.assertEquals;
 
-import java.io.IOException;
-import java.time.Clock;
-import java.time.ZoneOffset;
 import org.dpppt.backend.sdk.model.gaen.GaenKey;
 import org.dpppt.backend.sdk.model.gaen.GaenKeyForInterops;
 import org.junit.jupiter.api.Test;
 
 public class EfgsDsosUtilTest {
   @Test
-  void testDsosMapping(){
+  void testDsosMapping() {
     var now = UTCInstant.now();
 
     testWithSubmissionTime(now.atStartOfDay().plusHours(1));
@@ -28,7 +25,9 @@ public class EfgsDsosUtilTest {
     submissionDateKey.setRollingStartNumber(
         (int) submissionTime.atStartOfDay().get10MinutesSince1970());
 
-    assertEquals(DSOS_SYMPTOMATIC_UNKNOWN_ONSET_ZERO_POINT, EfgsDsosUtil.calculateDefaultDsosMapping(submissionDateKey));
+    assertEquals(
+        DSOS_SYMPTOMATIC_UNKNOWN_ONSET_ZERO_POINT,
+        EfgsDsosUtil.calculateDefaultDsosMapping(submissionDateKey));
 
     GaenKeyForInterops submissionPlus3Key = new GaenKeyForInterops();
     submissionPlus3Key.setGaenKey(new GaenKey());
@@ -36,7 +35,9 @@ public class EfgsDsosUtilTest {
     submissionPlus3Key.setRollingStartNumber(
         (int) submissionTime.plusDays(3).atStartOfDay().get10MinutesSince1970());
 
-    assertEquals(DSOS_SYMPTOMATIC_UNKNOWN_ONSET_ZERO_POINT + 3, EfgsDsosUtil.calculateDefaultDsosMapping(submissionPlus3Key));
+    assertEquals(
+        DSOS_SYMPTOMATIC_UNKNOWN_ONSET_ZERO_POINT + 3,
+        EfgsDsosUtil.calculateDefaultDsosMapping(submissionPlus3Key));
 
     GaenKeyForInterops submissionMinus10Key = new GaenKeyForInterops();
     submissionMinus10Key.setGaenKey(new GaenKey());
@@ -44,6 +45,8 @@ public class EfgsDsosUtilTest {
     submissionMinus10Key.setRollingStartNumber(
         (int) submissionTime.minusDays(10).atStartOfDay().get10MinutesSince1970());
 
-    assertEquals(DSOS_SYMPTOMATIC_UNKNOWN_ONSET_ZERO_POINT - 10, EfgsDsosUtil.calculateDefaultDsosMapping(submissionMinus10Key));
+    assertEquals(
+        DSOS_SYMPTOMATIC_UNKNOWN_ONSET_ZERO_POINT - 10,
+        EfgsDsosUtil.calculateDefaultDsosMapping(submissionMinus10Key));
   }
 }

--- a/dpppt-backend-sdk/dpppt-backend-sdk-model/src/test/java/org/dpppt/backend/sdk/utils/EfgsDsosUtilTest.java
+++ b/dpppt-backend-sdk/dpppt-backend-sdk-model/src/test/java/org/dpppt/backend/sdk/utils/EfgsDsosUtilTest.java
@@ -1,5 +1,6 @@
 package org.dpppt.backend.sdk.utils;
 
+import static org.dpppt.backend.sdk.utils.EfgsDsosUtil.DSOS_SYMPTOMATIC_UNKNOWN_ONSET_ZERO_POINT;
 import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
@@ -27,7 +28,7 @@ public class EfgsDsosUtilTest {
     submissionDateKey.setRollingStartNumber(
         (int) submissionTime.atStartOfDay().get10MinutesSince1970());
 
-    assertEquals(2000, EfgsDsosUtil.calculateDefaultDsosMapping(submissionDateKey));
+    assertEquals(DSOS_SYMPTOMATIC_UNKNOWN_ONSET_ZERO_POINT, EfgsDsosUtil.calculateDefaultDsosMapping(submissionDateKey));
 
     GaenKeyForInterops submissionPlus3Key = new GaenKeyForInterops();
     submissionPlus3Key.setGaenKey(new GaenKey());
@@ -35,7 +36,7 @@ public class EfgsDsosUtilTest {
     submissionPlus3Key.setRollingStartNumber(
         (int) submissionTime.plusDays(3).atStartOfDay().get10MinutesSince1970());
 
-    assertEquals(2000 + 3, EfgsDsosUtil.calculateDefaultDsosMapping(submissionPlus3Key));
+    assertEquals(DSOS_SYMPTOMATIC_UNKNOWN_ONSET_ZERO_POINT + 3, EfgsDsosUtil.calculateDefaultDsosMapping(submissionPlus3Key));
 
     GaenKeyForInterops submissionMinus10Key = new GaenKeyForInterops();
     submissionMinus10Key.setGaenKey(new GaenKey());
@@ -43,6 +44,6 @@ public class EfgsDsosUtilTest {
     submissionMinus10Key.setRollingStartNumber(
         (int) submissionTime.minusDays(10).atStartOfDay().get10MinutesSince1970());
 
-    assertEquals(2000 - 10, EfgsDsosUtil.calculateDefaultDsosMapping(submissionMinus10Key));
+    assertEquals(DSOS_SYMPTOMATIC_UNKNOWN_ONSET_ZERO_POINT - 10, EfgsDsosUtil.calculateDefaultDsosMapping(submissionMinus10Key));
   }
 }


### PR DESCRIPTION
This PR adds unit tests for the DSOS (days since onset of symptoms) calculation when uploading to an EFGS-compatible hub.  The third commit fixes the calculation, which did not calculate calendar days (inclusive) but 24h-days. 